### PR TITLE
Convert 'drop' statement to only drop existing 'openvragen' table

### DIFF
--- a/tkconv.cc
+++ b/tkconv.cc
@@ -934,7 +934,7 @@ Hasref: {"commissie"}
   sqlw.query("delete from Link where rowid in(select Link.rowid from Link,(select van,naar,linkSoort,max(rowid) as mrowid, count(1) c from Link group by 1,2,3 having c > 1) as t where Link.van=t.van and Link.naar=t.naar and link.linkSoort=t.linkSoort and Link.rowid < mrowid)");
 
   cout<<"Render queries.. "<<endl;
-  sqlw.query("drop table openvragen");
+  sqlw.query("drop table if exists openvragen");
   sqlw.query(R"(create table openvragen as select Zaak.id, Zaak.gestartOp, zaak.nummer, min(document.nummer) as docunummer, zaak.onderwerp, count(1) filter (where Document.soort="Schriftelijke vragen") as numvragen, count(1) filter (where Document.soort like "Antwoord schriftelijke vragen%" or (Document.soort="Mededeling" and (document.onderwerp like '%ingetrokken%' or document.onderwerp like '%intrekken%'))) as numantwoorden, count(1) filter (where Document.soort like '%uitstel%') as numuitstel  from Zaak, Link, Document where Zaak.id = Link.naar and Document.id = Link.van and Zaak.gestartOp > '2019-09-09' group by 1, 3 having numvragen > 0 and numantwoorden==0 order by 2 desc)");
   
 }


### PR DESCRIPTION
This PR fixes an issue I encountered where `tkconv` fails the 'render queries' step when missing the `openvragen` table.

After building the codebase as described in the Readme, and running the pipeline tools as described (`./build/tkgetxml && ./build/tkconv && ./build/tkpull && ./build/tkindex`), the `tkconv` utility fails when attempting to delete a non-existing table.

> Render queries..
> terminate called after throwing an instance of 'std::runtime_error'
>   what():  Unable to prepare query drop table openvragen: no such table: openvragen
> Aborted

Most likely, a prior termination of one of the components left the database in an inconsistent state, so the root cause of this is sort of an operator error. Anyway, innocently enough, replacing the DROP statement on line 937 of tkconv.cc with

>   sqlw.query("drop table if exists openvragen");

fixed the issue for me.