### PR TITLE
Add HTML escaping to error page

### DIFF
--- a/tkserv.cc
+++ b/tkserv.cc
@@ -1464,7 +1464,7 @@ int main(int argc, char** argv)
     try {
       std::rethrow_exception(ep);
     } catch (std::exception &e) {
-      snprintf(buf, sizeof(buf), fmt, e.what());
+      snprintf(buf, sizeof(buf), fmt, htmlEscape(e.what()).c_str());
     } catch (...) { // See the following NOTE
       snprintf(buf, sizeof(buf), fmt, "Unknown Exception");
     }


### PR DESCRIPTION
This adds HTML escaping to the "Error 500" error page in tkserv, so that even if there is a way for an attacker to cause an exception with a specific message, this does not turn into an XSS issue.