### PR TITLE
Instructies voor bouwen op een Mac.

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,15 @@ Ook is de nieuwste versie van pandoc nodig in productie, nieuwer dan in
 Debian Bookworm. [3.5 werkt
 goed](https://github.com/jgm/pandoc/releases/tag/3.5).
 
+### Op een Mac
+
+```bash
+brew install nlohmann-json sqlite pugixml poppler imagemagick pkgconf \
+xmlstarlet meson pandoc
+```
+
+Zie `mac-support/` voor installatie van `catdoc`.
+
 ## Lokaal draaien
 
 Alles wil draaien vanuit de root directory van het project.

--- a/mac-support/README.md
+++ b/mac-support/README.md
@@ -1,0 +1,4 @@
+
+catdoc zit niet (meer) in homebrew.
+
+Zelf bouwen met `brew install --build-from-source --formula ./catdoc.rb`

--- a/mac-support/catdoc.rb
+++ b/mac-support/catdoc.rb
@@ -1,0 +1,22 @@
+require 'formula'
+
+class Catdoc < Formula  
+  url 'http://ftp.wagner.pp.ru/pub/catdoc/catdoc-0.95.tar.gz'
+  homepage 'http://wagner.pp.ru/~vitus/software/catdoc/'
+  sha256 '514a84180352b6bf367c1d2499819dfa82b60d8c45777432fa643a5ed7d80796'  
+
+  def install    
+
+  # catdoc configure says it respects --mandir=, but does not.    
+  ENV['man1dir'] = man1
+  system "./configure --disable-debug --disable-dependency-tracking --prefix=#{prefix}"    
+
+  # The INSTALL file confuses make on case insensitive filesystems.    
+  system "mv INSTALL INSTALL.txt"
+  system "make"    
+
+  # There is a race condition in the charsets/Makefile install target. The following line solves it.    
+  system "make -C charsets install-dirs"   
+  system "make install"  
+  end
+end

--- a/support.cc
+++ b/support.cc
@@ -112,7 +112,7 @@ bool cacheIsNewer(const std::string& id, const std::string& cacheprefix, const s
   if(ret < 0 || sborig.st_size == 0) // if orig is gone, cache is newer!
     return true;
 
-  return sborig.st_mtim.tv_sec < sbcache.st_mtim.tv_sec;
+  return sborig.st_mtime < sbcache.st_mtime;
 }
 
 


### PR DESCRIPTION
De change naar st_mtime zou het meer portable moeten maken, het is in ieder geval nodig op de Mac. Zie `man fstat`.