### PR TITLE
Geef stemmingen een kleurtje afhankelijk resultaat

### DIFF
--- a/partials/custom.css
+++ b/partials/custom.css
@@ -9,3 +9,11 @@ tr,td {
           background-color: var(--pico-mark-background-color);
 }
 span.jarig::before { content: '🎈'; }
+
+.stemming.meervoor .besluittekst {
+    background-color: var(--pico-form-element-valid-border-color);
+}
+
+.stemming.meertegen .besluittekst {
+    background-color: var(--pico-form-element-invalid-border-color);
+}

--- a/partials/stemmingen.html
+++ b/partials/stemmingen.html
@@ -19,13 +19,13 @@
   {% for d in stemmingen %}
     <tbody>
       <tr class="stemming{% if default(d.voorstemmen, 0) > default(d.tegenstemmen, 0) %} meervoor{% endif %}{% if default(d.tegenstemmen, 0) > default(d.voorstemmen, 0) %} meertegen{% endif %}">
-	<td class="datum"> {{d.datum}} </td>
-	<td class="zaak"><a href="zaak.html?nummer={{d.znummer}}">{{d.zonderwerp}}</a></td>
-	<td class="indiener">{{d.indiener}} </td>
+	<td> {{d.datum}} </td>
+	<td><a href="zaak.html?nummer={{d.znummer}}">{{d.zonderwerp}}</a></td>
+	<td>{{d.indiener}} </td>
 	<td class="besluittekst">{{d.besluittekst}}</td>
 	
-	<td class="voorstemmen">{{default(d.voorstemmen, "")}}</td>
-	<td class="tegenstemmen">{{default(d.tegenstemmen, "")}}</td>
+	<td>{{default(d.voorstemmen, "")}}</td>
+	<td>{{default(d.tegenstemmen, "")}}</td>
       </tr>
       <tr>
 	<td></td>

--- a/partials/stemmingen.html
+++ b/partials/stemmingen.html
@@ -18,14 +18,14 @@
   </thead>
   {% for d in stemmingen %}
     <tbody>
-      <tr>
-	<td> {{d.datum}} </td>
-	<td><a href="zaak.html?nummer={{d.znummer}}">{{d.zonderwerp}}</a></td>
-	<td>{{d.indiener}} </td>
-	<td>{{d.besluittekst}}</td>	  
+      <tr class="stemming{% if default(d.voorstemmen, 0) > default(d.tegenstemmen, 0) %} meervoor{% endif %}{% if default(d.tegenstemmen, 0) > default(d.voorstemmen, 0) %} meertegen{% endif %}">
+	<td class="datum"> {{d.datum}} </td>
+	<td class="zaak"><a href="zaak.html?nummer={{d.znummer}}">{{d.zonderwerp}}</a></td>
+	<td class="indiener">{{d.indiener}} </td>
+	<td class="besluittekst">{{d.besluittekst}}</td>
 	
-	<td>{{default(d.voorstemmen, "")}}</td>
-	<td>{{default(d.tegenstemmen, "")}}</td>
+	<td class="voorstemmen">{{default(d.voorstemmen, "")}}</td>
+	<td class="tegenstemmen">{{default(d.tegenstemmen, "")}}</td>
       </tr>
       <tr>
 	<td></td>


### PR DESCRIPTION
Een stemming met meer voorstemmen dan tegenstemmen krijgt een groen kleurtje, andersom een rood kleurtje.

In duistere modus ziet zulks er zo uit:

![Screenshot 2025-01-03 at 14-21-30 Stemmingen – OpenTK](https://github.com/user-attachments/assets/61f605d3-7ae0-4627-b0ea-801e2f3e8fc6)

In heldere modus:

![Screenshot 2025-01-03 at 14-21-40 Stemmingen – OpenTK](https://github.com/user-attachments/assets/ff994d75-f932-4aa8-87d0-d3b7add7715d)


Fixes #12.