### PR TITLE
Voeg verklarende tooltip toe aan actorafkortingen

### DIFF
--- a/partials/activiteiten.html
+++ b/partials/activiteiten.html
@@ -17,7 +17,7 @@
     <tr>
       <td> {{d.datum }}</td>
       <td> {{d.naam}}</td>
-      <td> {{d.voortouwAfkorting}}</td>
+      <td> <abbr title="{{d.voortouwNaam}}">{{d.voortouwAfkorting}}</abbr></td>
       <td><a href="activiteit.html?nummer={{d.nummer}}"> {{d.onderwerp}}</a></td>
       <td> {{d.noot}}</td>
     </tr>

--- a/partials/index.html
+++ b/partials/index.html
@@ -47,7 +47,7 @@ Meest recente documenten (live updates)
       <tr>
 	<td>{{ d.datum }}</td>
 	<td>{{ d.bijgewerkt }}</td>
-	<td>{{ d.afkorting }}</td>
+	<td><abbr title="{{ d.naam }}">{{ d.afkorting }}</abbr></td>
 	{% if d.soort != "Verslag" %}
 	<td> {{ d.onderwerp }}  (<a href="document.html?nummer={{d.nummer}}">{{d.nummer}}</a>)</td>
 	{% else %}

--- a/partials/ongeplande-activiteiten.html
+++ b/partials/ongeplande-activiteiten.html
@@ -15,7 +15,7 @@
     {% for d in data %}
     <tr>
       <td> {{d.bijgewerkt}} </td>
-      <td> {{d.voortouwAfkorting}}</td>
+      <td> <abbr title="{{d.voortouwNaam}}">{{d.voortouwAfkorting}}</abbr></td>
       <td><a href="activiteit.html?nummer={{d.nummer}}"> {{d.onderwerp}}</a></td>
       <td> {{d.noot}} {{d.soort}}</td>
     </tr>

--- a/partials/toezeggingen.html
+++ b/partials/toezeggingen.html
@@ -20,7 +20,7 @@
     <tr>
       <td>{{d.datum}}</td>
       <td>{{d.status}}</td>
-      <td>{{d.voortouwAfkorting}}</td>
+      <td><abbr title="{{d.voortouwNaam}}">{{d.voortouwAfkorting}}</abbr></td>
       <td><a href="activiteit.html?nummer={{d.activiteitNummer}}">{{d.tekst}}</a></td>
       <td> {{d.naamToezegger}}</td>
       <td> {{d.ministerie}}</td>

--- a/tkserv.cc
+++ b/tkserv.cc
@@ -881,7 +881,7 @@ int main(int argc, char** argv)
   doTemplate("geschenken.html", "geschenken.html", "select datum, omschrijving, functie, initialen, tussenvoegsel, roepnaam, achternaam, gewicht,nummer,substr(persoongeschenk.bijgewerkt,0,11)  pgbijgewerkt from persoonGeschenk, Persoon where Persoon.id=persoonId and datum > '2019-01-01' order by persoongeschenk.bijgewerkt desc");
 
 
-  doTemplate("toezeggingen.html", "toezeggingen.html", "select toezegging.id, tekst, toezegging.nummer, ministerie, status, naamToezegger, substr(activiteit.datum, 0, 11) datum, kamerbriefNakoming, datumNakoming, activiteit.nummer activiteitNummer, initialen, tussenvoegsel, achternaam, functie, fractie.afkorting as fractienaam, voortouwAfkorting from Toezegging,Activiteit left join Persoon on persoon.id = toezegging.persoonId left join Fractie on fractie.id = toezegging.fractieId where  Toezegging.activiteitId = activiteit.id and status != 'Voldaan' order by activiteit.datum desc");
+  doTemplate("toezeggingen.html", "toezeggingen.html", "select toezegging.id, tekst, toezegging.nummer, ministerie, status, naamToezegger, substr(activiteit.datum, 0, 11) datum, kamerbriefNakoming, datumNakoming, activiteit.nummer activiteitNummer, initialen, tussenvoegsel, achternaam, functie, fractie.afkorting as fractienaam, voortouwAfkorting, voortouwNaam from Toezegging,Activiteit left join Persoon on persoon.id = toezegging.persoonId left join Fractie on fractie.id = toezegging.fractieId where  Toezegging.activiteitId = activiteit.id and status != 'Voldaan' order by activiteit.datum desc");
 
   
   sws.d_svr.Get("/index.html", [](const httplib::Request &req, httplib::Response &res) {
@@ -1103,7 +1103,7 @@ int main(int argc, char** argv)
     // from 4 days ago into the future
     string dlim = fmt::format("{:%Y-%m-%d}", fmt::localtime(time(0)-4*86400));
     
-    auto acts = packResultsJson(tp.getLease()->queryT("select Activiteit.datum datum, activiteit.bijgewerkt bijgewerkt, activiteit.nummer nummer, naam, noot, onderwerp,voortouwAfkorting from Activiteit left join Reservering on reservering.activiteitId=activiteit.id  left join Zaal on zaal.id=reservering.zaalId where datum > ? order by datum asc", {dlim})); 
+    auto acts = packResultsJson(tp.getLease()->queryT("select Activiteit.datum datum, activiteit.bijgewerkt bijgewerkt, activiteit.nummer nummer, naam, noot, onderwerp, voortouwAfkorting, voortouwNaam from Activiteit left join Reservering on reservering.activiteitId=activiteit.id  left join Zaal on zaal.id=reservering.zaalId where datum > ? order by datum asc", {dlim}));
 
     for(auto& a : acts) {
       a["naam"] = htmlEscape(a["naam"]);


### PR DESCRIPTION
Met de muis over "TCGCT" zweven geeft bijvoorbeeld "tijdelijke commissie Grondrechten en en constitutionele toetsing", voor de bezoekers als ik die die afkortingen niet allemaal paraat hebben.

![s](https://github.com/user-attachments/assets/a1eaaa40-de74-4e6e-ab01-4abfb2d1b77b)

De afkortingen krijgen een onderstippeling om aan te geven dat dit mogelijk is.

Fixes #22.