### PR TITLE
Opzet Docker compose stack voor eenvouding lokaal draaien

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ tk.sqlite3-wal
 xml.sqlite3
 xml.sqlite3-shm
 xml.sqlite3-wal
+docker-compose.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,17 +9,22 @@ RUN apt-get update && \
     apt-get install -y \
     git \
     build-essential \
+    catdoc \
     meson \
     ninja-build \
+    pandoc \
     pkg-config \
+    poppler-utils \
     nlohmann-json3-dev \
-    libsqlite3-dev \ 
+    libsqlite3-dev \
     libpugixml-dev \
     libpq-dev \
-    cmake
+    sqlite3 \
+    cmake \
+    xmlstarlet
 
 # Set the working directory inside the container
-WORKDIR /app
+WORKDIR /workdir
 
 # Copy the project files to the container
 COPY . .
@@ -27,7 +32,18 @@ COPY . .
 # Create build directory, compile project with meson and install
 RUN meson setup build && \
    meson compile -C build &&\
-   cp -r build/* /usr/local/bin/
+   cp -r build/* /usr/local/bin/ &&\
+   cp docker/tksync.sh /usr/local/bin/tksync &&\
+   chmod +x /usr/local/bin/tksync
+
+WORKDIR /app
+
+RUN cp -r /workdir/html/ html/ &&\
+    cp -r /workdir/partials/ partials/ &&\
+    cp -r /workdir/build/ build/ &&\
+    cp /workdir/tk.xslt tk.xslt &&\
+    cp /workdir/tk-div.xslt tk-div.xslt
 
 # Default command to run when the container starts (modify as needed)
+# start with `tksync` to loop through all sync scripts
 CMD ["tkserv"]

--- a/README.md
+++ b/README.md
@@ -121,6 +121,19 @@ docker run -it -v $PWD:/app --rm tkconv:latest tkconv
 docker run -it -v $PWD:/app -p 8089:8089 --rm tkconv:latest tkserv
 ```
 
+## via docker compose
+
+Voor snelle start met hele stack kan je ook gebruik maken van docker-compose.yml file.
+Hiermee draai je de webserver en cronjob tegelijkertijd in één compose stack.
+Zorg dat docker [geinstalleerd is](https://docs.docker.com/engine/install/),
+clone deze repository en gebruik de volgende commando om de stack te starten:
+
+```shell
+docker-compose up -d
+```
+
+**TODO:** De mailserver is niet geconfigureerd in de docker-compose.yml file.
+
 ## zelf vanuit source compileren
 Als je de boel zelf wil draaien heb je ongeveer zoveel data nodig:
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+---
+services:
+  tksync:
+    build:
+        context: .
+        dockerfile: Dockerfile
+    command:
+      - tksync
+    restart: unless-stopped
+    volumes:
+      - data:/app
+
+  tkserv:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command:
+      - tkserv
+    restart: unless-stopped
+    ports:
+      - "8089:8089"
+    volumes:
+      - data:/app
+
+volumes:
+  data:

--- a/docker/tksync.sh
+++ b/docker/tksync.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+while true
+do
+  cp -r /workdir/html /app/html
+  cp -r /workdir/partials /app/partials
+  cp -r /workdir/build /app/build
+  cp /workdir/tk.xslt /app/tk.xslt
+  cp /workdir/tk-div.xslt /app/tk-div.xslt
+  tkgetxml
+  tkconv
+  sqlite3 tk.sqlite3 < /workdir/maak-indexen || true
+  tkpull
+  oppull
+  oppull xml
+  tkparse
+  tkindex
+  tkindex --days=14 --tkindex tkindex-small.sqlite3
+  echo sleeping
+  sleep 60
+done

--- a/maak-indexen
+++ b/maak-indexen
@@ -1,34 +1,34 @@
-CREATE INDEX datumindex on Document(datum);
-CREATE INDEX nummerdocidx on Document(nummer);
+CREATE INDEX IF NOT EXISTS datumindex on Document(datum);
+CREATE INDEX IF NOT EXISTS nummerdocidx on Document(nummer);
 
-CREATE INDEX zaindex on ZaakActor(zaakId);
-CREATE INDEX zaindex2 on ZaakActor(zaakId, relatie);
-CREATE INDEX docactordocidx on DocumentActor(documentId);
-CREATE INDEX persoongeschenkpersidx on persoonGeschenk(persoonId);
-CREATE INDEX zaakgestartidx on zaak(gestartOp);
-CREATE INDEX zaaksoortidx on Document(soort);
+CREATE INDEX IF NOT EXISTS zaindex on ZaakActor(zaakId);
+CREATE INDEX IF NOT EXISTS zaindex2 on ZaakActor(zaakId, relatie);
+CREATE INDEX IF NOT EXISTS docactordocidx on DocumentActor(documentId);
+CREATE INDEX IF NOT EXISTS persoongeschenkpersidx on persoonGeschenk(persoonId);
+CREATE INDEX IF NOT EXISTS zaakgestartidx on zaak(gestartOp);
+CREATE INDEX IF NOT EXISTS zaaksoortidx on Document(soort);
 
-CREATE INDEX actdatumidx on Activiteit(datum);
-CREATE INDEX agendapuntactidx on agendapunt(activiteitid);
-CREATE INDEX besluitagendapunt on besluit(agendapuntId);
+CREATE INDEX IF NOT EXISTS actdatumidx on Activiteit(datum);
+CREATE INDEX IF NOT EXISTS agendapuntactidx on agendapunt(activiteitid);
+CREATE INDEX IF NOT EXISTS besluitagendapunt on besluit(agendapuntId);
 
-CREATE INDEX docactorpersoonidx on DocumentActor(persoonId);
-create index stemmingbesluitidx on Stemming(besluitId);
-create index zaakbesluitidx on besluit(zaakid);
-CREATE INDEX zaaknumidx on zaak(nummer);
-CREATE INDEX zaakactorpersoonidx on zaakactor(persoonid);
-create index docagendapuntidx on document(agendapuntid);
-CREATE INDEX activactoridx on activiteitactor(activiteitid);
-CREATE INDEX actcomidx on activiteitactor(commissieId);
-CREATE INDEX zaakcomidx on zaakactor(commissieid);
+CREATE INDEX IF NOT EXISTS docactorpersoonidx on DocumentActor(persoonId);
+CREATE INDEX IF NOT EXISTS stemmingbesluitidx on Stemming(besluitId);
+CREATE INDEX IF NOT EXISTS zaakbesluitidx on besluit(zaakid);
+CREATE INDEX IF NOT EXISTS zaaknumidx on zaak(nummer);
+CREATE INDEX IF NOT EXISTS zaakactorpersoonidx on zaakactor(persoonid);
+CREATE INDEX IF NOT EXISTS docagendapuntidx on document(agendapuntid);
+CREATE INDEX IF NOT EXISTS activactoridx on activiteitactor(activiteitid);
+CREATE INDEX IF NOT EXISTS actcomidx on activiteitactor(commissieId);
+CREATE INDEX IF NOT EXISTS zaakcomidx on zaakactor(commissieid);
 
-CREATE INDEX docversiedocidx on DocumentVersie(documentId);
-CREATE INDEX docversextid on DocumentVersie(externeidentifier);
-CREATE INDEX activiteitpersoonidx on activiteitactor(persoonid);
-CREATE INDEX persoonnummeridx on persoon(nummer);
-CREATE INDEX ksdindex on document(kamerstukdossierid);
-create index brondocidx on document(bronDocument);
-CREATE INDEX FractieZetelPersoon_idx ON FractieZetelPersoon(persoonId, fractieZetelId, van DESC);
-create index toezact on Toezegging(activiteitId);
+CREATE INDEX IF NOT EXISTS docversiedocidx on DocumentVersie(documentId);
+CREATE INDEX IF NOT EXISTS docversextid on DocumentVersie(externeidentifier);
+CREATE INDEX IF NOT EXISTS activiteitpersoonidx on activiteitactor(persoonid);
+CREATE INDEX IF NOT EXISTS persoonnummeridx on persoon(nummer);
+CREATE INDEX IF NOT EXISTS ksdindex on document(kamerstukdossierid);
+CREATE INDEX IF NOT EXISTS brondocidx on document(bronDocument);
+CREATE INDEX IF NOT EXISTS FractieZetelPersoon_idx ON FractieZetelPersoon(persoonId, fractieZetelId, van DESC);
+CREATE INDEX IF NOT EXISTS toezact on Toezegging(activiteitId);
 analyze;
 


### PR DESCRIPTION
Simpele docker compose stack toegevoegd, waardoor je met één commando kan draaien op omgeving waar docker geïnstalleerd staat.

Zit wel kleine workaround in om zorgen dat persistent data in volume zit, maar daar ook nodige statische bestanden aanwezig zijn. Dit zou mooier kunnen als dat geheel gescheiden is.