### PR TITLE
Fix: XML tabel schema probleem in tkgetxml.cc

### DIFF
--- a/tkgetxml.cc
+++ b/tkgetxml.cc
@@ -29,7 +29,7 @@ int main(int argc, char** argv)
   }
   SQLiteWriter sqlw("xml.sqlite3");
   for(const auto& category: categories) {
-    sqlw.query("create table if not exists "+category+" (skiptoken INT)");
+    sqlw.query("create table if not exists "+category+" (category TEXT, id TEXT, skiptoken INT, enclosure TEXT, updated TEXT, xml TEXT)");
     sqlw.query("create index if not exists "+category+"skipidx on "+category+"(skiptoken)");
     string next="https://gegevensmagazijn.tweedekamer.nl/SyncFeed/2.0/Feed?category=" + category;
     int skiptoken = -1;


### PR DESCRIPTION
**Achtergrond:**
In local development is het fijn om met een kleine subset aan data te kunnen experimenteren (partiële data sync, bv. met een hoge skiptoken, hiervoor heb ik een optionele docker compose override file gemaakt en een tksync die een hogere skiptoken probeert (en exponentieel verlaagd bij 0 hits) tot er voor alle entiteiten data is aangetroffen).. Op deze manier kun je lokaal snel en eenvoudig starten met bijvoorbeeld afgelopen maand (als je ongeveer weet welke skiptoken dan een goed eikpunt is).
Het lijkt erop dat de repository altijd uitgaat van een full historic sync zijn een aantal issues waarschijnlijk nooit aan het licht gekomen;

**Issue:**
De tabel wordt aangemaakt met alleen (skiptoken INT) maar de insert probeert 6 kolommen: category, id, skiptoken, enclosure, updated, xml
Bij volledige sync vanaf begin werkt het 'toevallig', maar bij een hogere skiptoken sync faalt XML opslag compleet

'xml field is not a string' fouten omdat geen XML content wordt opgeslagen

**Oplossing:**
Tabel schema uitgebreid naar alle benodigde kolommen