### PR TITLE
Voeg Activiteit en filtering toe aan RSS

### DIFF
--- a/html/logic.js
+++ b/html/logic.js
@@ -304,6 +304,7 @@ async function getSearchResults(f)
         f.foundDocs = data["results"];
 	const rssurl = new URL("https://berthub.eu/tkconv/search/index.xml");
 	rssurl.searchParams.set("q", f.searchQuery);
+	rssurl.searchParams.set("soorten", f.soorten);
 	f.rssurl = rssurl.href
 
 	f.message = `${data["milliseconds"]} milliseconden`;

--- a/partials/search.html
+++ b/partials/search.html
@@ -21,7 +21,7 @@ kind: 'zoek'
 {% endblock %}
 
 {% block extrameta %}
-<link rel="alternate" type="application/rss+xml" href="https://berthub.eu/tkconv/search/index.xml?q={{q}}" title="OpenTK zoek RSS" />
+<link rel="alternate" type="application/rss+xml" href="https://berthub.eu/tkconv/search/index.xml?q={{q}}&soorten={{soorten}}" title="OpenTK zoek RSS" />
 {% endblock %}
 
 {% block customheader %}

--- a/search.cc
+++ b/search.cc
@@ -1,6 +1,17 @@
 #include "search.hh"
 #include "support.hh"
+#include <fmt/format.h>
 using namespace std;
+
+RSSItem makeRSSItem(const SearchHelper::Result& r, const std::string& naam)
+{
+  RSSItem item;
+  item.title = r.onderwerp;
+  item.description = naam + " | " + r.titel + " " + r.onderwerp;
+  item.link = fmt::format("https://berthub.eu/tkconv/document.html?nummer={}", r.nummer);
+  item.guid = "tkconv_" + r.nummer;
+  return item;
+}
 
 
 std::vector<SearchHelper::Result> SearchHelper::search(const std::string& query, const std::set<string>& categories, const std::string& cutoff, unsigned int mseclimit, unsigned int itemlimit)

--- a/search.cc
+++ b/search.cc
@@ -13,6 +13,20 @@ RSSItem makeRSSItem(const SearchHelper::Result& r, const std::string& naam)
   return item;
 }
 
+bool searchResultMatchesSoorten(const SearchHelper::Result& r, const std::string& soorten)
+{
+  if(soorten == "documenten")
+    return r.categorie == "Document";
+  if(soorten == "moties")
+    return r.soort == "Motie";
+  if(soorten == "vragenantwoorden") {
+    return r.soort == "Schriftelijke vragen" ||
+      r.soort == "Antwoord schriftelijke vragen" ||
+      r.soort == "Antwoord schriftelijke vragen (nader)";
+  }
+  return true;
+}
+
 
 std::vector<SearchHelper::Result> SearchHelper::search(const std::string& query, const std::set<string>& categories, const std::string& cutoff, unsigned int mseclimit, unsigned int itemlimit)
 {

--- a/search.cc
+++ b/search.cc
@@ -7,9 +7,18 @@ RSSItem makeRSSItem(const SearchHelper::Result& r, const std::string& naam)
 {
   RSSItem item;
   item.title = r.onderwerp;
-  item.description = naam + " | " + r.titel + " " + r.onderwerp;
-  item.link = fmt::format("https://berthub.eu/tkconv/document.html?nummer={}", r.nummer);
-  item.guid = "tkconv_" + r.nummer;
+
+  if(r.categorie == "Document") {
+    item.description = naam + " | " + r.titel + " " + r.onderwerp;
+    item.link = fmt::format("https://berthub.eu/tkconv/document.html?nummer={}", r.nummer);
+    item.guid = "tkconv_" + r.nummer;
+  } else {
+    item.description = r.onderwerp;
+    if(!r.soort.empty())
+      item.description = r.soort + " | " + item.description;
+    item.link = fmt::format("https://berthub.eu/tkconv/{}", r.relurl);
+    item.guid = "tkconv_" + r.relurl;
+  }
   return item;
 }
 

--- a/search.hh
+++ b/search.hh
@@ -43,4 +43,14 @@ struct SearchHelper
   
   SQLiteWriter& d_sqw;
 };
+
+struct RSSItem
+{
+  std::string title;
+  std::string description;
+  std::string link;
+  std::string guid;
+};
+RSSItem makeRSSItem(const SearchHelper::Result& r, const std::string& naam);
+
 std::set<std::pair<std::string, std::string>> getZakenFromDocument(const std::string& id);

--- a/search.hh
+++ b/search.hh
@@ -53,4 +53,6 @@ struct RSSItem
 };
 RSSItem makeRSSItem(const SearchHelper::Result& r, const std::string& naam);
 
+bool searchResultMatchesSoorten(const SearchHelper::Result& r, const std::string& soorten);
+
 std::set<std::pair<std::string, std::string>> getZakenFromDocument(const std::string& id);

--- a/testrunner.cc
+++ b/testrunner.cc
@@ -159,6 +159,22 @@ TEST_CASE("searchResultMatchesSoorten")
   CHECK_FALSE(searchResultMatchesSoorten(activiteit, "documenten"));
 }
 
+TEST_CASE("makeRSSItem for Activiteit 2026A01281")
+{
+  SearchHelper::Result r;
+  r.nummer = "2026A01281";
+  r.categorie = "Activiteit";
+  r.relurl = "activiteit.html?nummer=2026A01281";
+  r.onderwerp = "Aanvang middagvergadering: STEMMINGEN (over de Wet werkelijk rendement box 3) en over moties ingediend bij het Tweeminutendebat Voorhang wijziging Postbesluit 2009)";
+  r.soort = "Stemmingen";
+
+  auto item = makeRSSItem(r, "");
+  CHECK(item.title == r.onderwerp);
+  CHECK(item.description == "Stemmingen | " + r.onderwerp);
+  CHECK(item.link == "https://berthub.eu/tkconv/activiteit.html?nummer=2026A01281");
+  CHECK(item.guid == "tkconv_activiteit.html?nummer=2026A01281");
+}
+
 TEST_CASE("Send email" * doctest::skip())
 {
   string text("* Zoekopdracht motie paulusma:\nhttp://berthub.eu/tkconv/get/2024D49539: Voortgangsbrief beschikbaarheid geneesmiddelen\n\nDit was een bericht van https://berthub.eu/tkconv, ook bekend als OpenTK");

--- a/testrunner.cc
+++ b/testrunner.cc
@@ -138,6 +138,27 @@ TEST_CASE("makeRSSItem for Schriftelijke vragen 2026D10272")
   CHECK(item.guid == "tkconv_2026D10272");
 }
 
+TEST_CASE("searchResultMatchesSoorten")
+{
+  SearchHelper::Result activiteit;
+  activiteit.categorie = "Activiteit";
+
+  SearchHelper::Result motie;
+  motie.categorie = "Document";
+  motie.soort = "Motie";
+
+  SearchHelper::Result antwoord;
+  antwoord.categorie = "Document";
+  antwoord.soort = "Antwoord schriftelijke vragen";
+
+  CHECK(searchResultMatchesSoorten(motie, "moties"));
+  CHECK_FALSE(searchResultMatchesSoorten(antwoord, "moties"));
+  CHECK(searchResultMatchesSoorten(antwoord, "vragenantwoorden"));
+  CHECK_FALSE(searchResultMatchesSoorten(activiteit, "vragenantwoorden"));
+  CHECK(searchResultMatchesSoorten(motie, "documenten"));
+  CHECK_FALSE(searchResultMatchesSoorten(activiteit, "documenten"));
+}
+
 TEST_CASE("Send email" * doctest::skip())
 {
   string text("* Zoekopdracht motie paulusma:\nhttp://berthub.eu/tkconv/get/2024D49539: Voortgangsbrief beschikbaarheid geneesmiddelen\n\nDit was een bericht van https://berthub.eu/tkconv, ook bekend als OpenTK");

--- a/testrunner.cc
+++ b/testrunner.cc
@@ -90,7 +90,53 @@ TEST_CASE("Test timestamps")
   CHECK(then == 1737094027);  
 }
 
+TEST_CASE("makeRSSItem for Document 2026D10396")
+{
+  SearchHelper::Result r;
+  r.nummer = "2026D10396";
+  r.categorie = "Document";
+  r.onderwerp = "Minimum vermogensbelasting van 2% voor zeer vermogende personen";
+  r.titel = "Herziening Belastingstelsel";
+  r.soort = "Brief regering";
 
+  auto item = makeRSSItem(r, "vaste commissie voor Financiën");
+  CHECK(item.title == "Minimum vermogensbelasting van 2% voor zeer vermogende personen");
+  CHECK(item.description == "vaste commissie voor Financiën | Herziening Belastingstelsel Minimum vermogensbelasting van 2% voor zeer vermogende personen");
+  CHECK(item.link == "https://berthub.eu/tkconv/document.html?nummer=2026D10396");
+  CHECK(item.guid == "tkconv_2026D10396");
+}
+
+TEST_CASE("makeRSSItem for Motie 2026D05246")
+{
+  SearchHelper::Result r;
+  r.nummer = "2026D05246";
+  r.categorie = "Document";
+  r.onderwerp = "Motie van het lid Vermeer";
+  r.titel = "Wijziging van de Wet inkomstenbelasting 2001 om werkelijke inkomsten uit bezittingen en schulden in box 3 te belasten (Wet werkelijk rendement box 3)";
+  r.soort = "Motie";
+
+  auto item = makeRSSItem(r, "vaste commissie voor Financiën");
+  CHECK(item.title == "Motie van het lid Vermeer");
+  CHECK(item.description == "vaste commissie voor Financiën | Wijziging van de Wet inkomstenbelasting 2001 om werkelijke inkomsten uit bezittingen en schulden in box 3 te belasten (Wet werkelijk rendement box 3) Motie van het lid Vermeer");
+  CHECK(item.link == "https://berthub.eu/tkconv/document.html?nummer=2026D05246");
+  CHECK(item.guid == "tkconv_2026D05246");
+}
+
+TEST_CASE("makeRSSItem for Schriftelijke vragen 2026D10272")
+{
+  SearchHelper::Result r;
+  r.nummer = "2026D10272";
+  r.categorie = "Document";
+  r.onderwerp = "Het terugkrijgen van belastingrente door belastingplichtigen die te veel hebben betaald in box 3";
+  r.titel = "";
+  r.soort = "Schriftelijke vragen";
+
+  auto item = makeRSSItem(r, "");
+  CHECK(item.title == "Het terugkrijgen van belastingrente door belastingplichtigen die te veel hebben betaald in box 3");
+  CHECK(item.description == " |  Het terugkrijgen van belastingrente door belastingplichtigen die te veel hebben betaald in box 3");
+  CHECK(item.link == "https://berthub.eu/tkconv/document.html?nummer=2026D10272");
+  CHECK(item.guid == "tkconv_2026D10272");
+}
 
 TEST_CASE("Send email" * doctest::skip())
 {

--- a/tkserv.cc
+++ b/tkserv.cc
@@ -2009,13 +2009,7 @@ int main(int argc, char** argv)
     auto sres = sh.search(term, categories, limit, mseclimit, 280);
     nlohmann::json results = nlohmann::json::array();
     for(const auto& r : sres) {
-      
-      if(soorten=="moties" && r.soort != "Motie")
-	continue;
-      else if(soorten=="vragenantwoorden" &&
-	 (r.soort != "Schriftelijke vragen" &&
-	  r.soort != "Antwoord schriftelijke vragen" &&
-	  r.soort != "Antwoord schriftelijke vragen (nader)"))
+      if(!searchResultMatchesSoorten(r, soorten))
 	continue;
 
       results.push_back(nlohmann::json({

--- a/tkserv.cc
+++ b/tkserv.cc
@@ -733,12 +733,14 @@ int main(int argc, char** argv)
 
   sws.wrapGet({}, "/search.html", [&tp](auto& cr) {
     string q = cr.req.get_param_value("q");
+    string soorten = cr.req.get_param_value("soorten");
     nlohmann::json data;
     data["pagemeta"]["title"]="Zoek naar "+htmlEscape(q);
     data["og"]["title"] = "Zoek naar "+htmlEscape(q);
     data["og"]["description"] = "Zoek naar "+htmlEscape(q);
     data["og"]["imageurl"] = "";
     data["q"] = urlEscape(q);
+    data["soorten"] = soorten.empty() ? "alles" : urlEscape(soorten);
     inja::Environment e;
     e.set_html_autoescape(false); // !!
       

--- a/users.cc
+++ b/users.cc
@@ -379,15 +379,13 @@ Goed inzicht in ons parlement is belangrijk, soms omdat er dingen in het nieuws 
       }
       auto& r = docs[0];
       pugi::xml_node item = channel.append_child("item");
-      string onderwerp = eget(r, "onderwerp");
-      item.append_child("title").append_child(pugi::node_pcdata).set_value(onderwerp.c_str());
-      onderwerp = eget(r, "naam")+" | " + eget(r, "titel") + " " + onderwerp;
-      item.append_child("description").append_child(pugi::node_pcdata).set_value(onderwerp.c_str());
+      auto rssItem = makeRSSItem(m, eget(r, "naam"));
+      item.append_child("title").append_child(pugi::node_pcdata).set_value(rssItem.title.c_str());
+      item.append_child("description").append_child(pugi::node_pcdata).set_value(rssItem.description.c_str());
 
       
-      item.append_child("link").append_child(pugi::node_pcdata).set_value(
-									  fmt::format("https://berthub.eu/tkconv/document.html?nummer={}", eget(r,"nummer")).c_str());
-	item.append_child("guid").append_child(pugi::node_pcdata).set_value(("tkconv_"+eget(r, "nummer")).c_str());
+      item.append_child("link").append_child(pugi::node_pcdata).set_value(rssItem.link.c_str());
+	item.append_child("guid").append_child(pugi::node_pcdata).set_value(rssItem.guid.c_str());
 
       // 2024-12-06T06:01:10.2530000
       string pubDate = eget(r, "bijgewerkt");

--- a/users.cc
+++ b/users.cc
@@ -371,15 +371,13 @@ Goed inzicht in ons parlement is belangrijk, soms omdat er dingen in het nieuws 
     
     
     for(auto& m : matches) {
-      auto docs = own.queryT("select Document.onderwerp, Document.titel titel, Document.nummer nummer, Document.bijgewerkt bijgewerkt, ZaakActor.naam naam, ZaakActor.afkorting afkorting from Document left join Link on link.van = document.id left join zaak on zaak.id = link.naar left join  ZaakActor on ZaakActor.zaakId = zaak.id and relatie = 'Voortouwcommissie'  where Document.nummer=?", {m.nummer});
+      string naam;
+      auto docs = own.queryT("select ZaakActor.naam from Document left join Link on link.van = document.id left join zaak on zaak.id = link.naar left join ZaakActor on ZaakActor.zaakId = zaak.id and relatie = 'Voortouwcommissie' where Document.nummer=?", {m.nummer});
+      if(!docs.empty())
+	naam = eget(docs[0], "naam");
 
-      if(docs.empty()) {
-	cout<<"No hits for "<< m.nummer<<endl;
-	continue;
-      }
-      auto& r = docs[0];
       pugi::xml_node item = channel.append_child("item");
-      auto rssItem = makeRSSItem(m, eget(r, "naam"));
+      auto rssItem = makeRSSItem(m, naam);
       item.append_child("title").append_child(pugi::node_pcdata).set_value(rssItem.title.c_str());
       item.append_child("description").append_child(pugi::node_pcdata).set_value(rssItem.description.c_str());
 
@@ -388,7 +386,7 @@ Goed inzicht in ons parlement is belangrijk, soms omdat er dingen in het nieuws 
 	item.append_child("guid").append_child(pugi::node_pcdata).set_value(rssItem.guid.c_str());
 
       // 2024-12-06T06:01:10.2530000
-      string pubDate = eget(r, "bijgewerkt");
+      string pubDate = m.bijgewerkt;
       time_t then = getTstamp(pubDate);
      
       //      <pubDate>Fri, 13 Dec 2024 14:13:41 +0000</pubDate>

--- a/users.cc
+++ b/users.cc
@@ -355,26 +355,41 @@ Goed inzicht in ons parlement is belangrijk, soms omdat er dingen in het nieuws 
   // https://berthub.eu/tkconv/search.html?q=bert+hubert&twomonths=false&soorten=alles
   sws.wrapGet({}, "/search/index.xml", [](auto& cr) {
     string q = convertToSQLiteFTS5(cr.req.get_param_value("q"));
-    string categorie;
+    string soorten = cr.req.get_param_value("soorten");
+
+    // Backward compatibility: existing RSS URLs have no soorten parameter
+    // and historically only returned Documents.  Treat absent soorten the
+    // same as the explicit "documenten" filter so new Activiteit items
+    // don't suddenly appear in existing subscribers' feeds.
+    if(soorten.empty())
+      soorten = "documenten";
 
     SQLiteWriter own("tkindex-small.sqlite3", SQLWFlag::ReadOnly);
     own.query("ATTACH database 'tk.sqlite3' as meta");
     SearchHelper sh(own);
 
-    // for now we can't do the rest, only Document XXX
-    auto matches = sh.search(q, {"Document"});
+    set<string> categories;
+    if(soorten=="activiteiten")
+      categories.insert("Activiteit");
+
+    auto matches = sh.search(q, categories);
     cout<<"Have "<<matches.size()<<" matches\n";
     pugi::xml_document doc;
-    pugi::xml_node channel = prepRSS(doc, "Zoek RSS naar " +q, "Documenten gematched door zoekstring "+q);
+    pugi::xml_node channel = prepRSS(doc, "Zoek RSS naar " +q, "Resultaten gematched door zoekstring "+q);
     
     bool first = true;
     
     
     for(auto& m : matches) {
+      if(!searchResultMatchesSoorten(m, soorten))
+	continue;
+
       string naam;
-      auto docs = own.queryT("select ZaakActor.naam from Document left join Link on link.van = document.id left join zaak on zaak.id = link.naar left join ZaakActor on ZaakActor.zaakId = zaak.id and relatie = 'Voortouwcommissie' where Document.nummer=?", {m.nummer});
-      if(!docs.empty())
-	naam = eget(docs[0], "naam");
+      if(m.categorie == "Document") {
+	auto docs = own.queryT("select ZaakActor.naam from Document left join Link on link.van = document.id left join zaak on zaak.id = link.naar left join ZaakActor on ZaakActor.zaakId = zaak.id and relatie = 'Voortouwcommissie' where Document.nummer=?", {m.nummer});
+	if(!docs.empty())
+	  naam = eget(docs[0], "naam");
+      }
 
       pugi::xml_node item = channel.append_child("item");
       auto rssItem = makeRSSItem(m, naam);


### PR DESCRIPTION
De twee belangrijkste wijzigingen zijn:

1. Voeg activiteiten (zoals commissiedebatten) toe aan de RSS feed
2. Ondersteun dezelfde `soorten` filtering als op de search pagina 

De RSS link op de zoekpagina zet (na deze PR) standaard `&soorten=alles`. Voor backwards compatilibity met de bestaande RSS feeds, wordt de afwezigheid van `soorten` geinterpreteerd als `soorten=documenten`, dus er komen geen nieuwe items tevoorschijn.

Fixes #113.

Met de nodige LLM hulp geschreven, maar wel lokaal getest.

Als je de commits op volgorde reviewt zou het goed te volgen moeten zijn:
- ~_Use root-relative RSS URL_: zodat de RSS feed link naar localhost gaat als de site lokaal draait (voor developers)~
- _Add makeRSSItem helper and test_: introduceert `struct RSSItem` en tests die aantonen dat de RSS entries niet per ongeluk veranderen in latere commmits (pure refactor)
- _Use search result fields directly in RSS handler_: maakt de XML query korter (pure refactor)
- _Extract searchResultMatchesSoorten helper_: om code duplicatie te voorkomen in de volgende commit (pure refactor)
- _Make search RSS honor soorten filters_: de daadwerkelijke wijziging