### PR TITLE
Add SITE_ROOT for easier local testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:24.04
 
 # Set the environment variables to prevent interactive prompts
 ENV DEBIAN_FRONTEND=noninteractive
+ENV SITE_ROOT=https://berthub.eu/tkconv
 
 # Install dependencies
 RUN apt-get update && \

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ builden en de gecompileerde bestanden uit te voeren:
 docker build --tag tkconv .
 docker run -it -v $PWD:/app --rm tkconv:latest tkgetxml
 docker run -it -v $PWD:/app --rm tkconv:latest tkconv
-docker run -it -v $PWD:/app -p 8089:8089 --rm tkconv:latest tkserv
+docker run -it -e SITE_ROOT=http://127.0.0.1:8089 -v $PWD:/app -p 8089:8089 --rm tkconv:latest tkserv
 ```
 
 ## via docker compose

--- a/html/logic.js
+++ b/html/logic.js
@@ -302,7 +302,7 @@ async function getSearchResults(f)
     if (response.ok === true) {
         const data = await response.json();
         f.foundDocs = data["results"];
-	const rssurl = new URL("https://berthub.eu/tkconv/search/index.xml");
+	const rssurl = new URL(f.siteRoot + "/search/index.xml");
 	rssurl.searchParams.set("q", f.searchQuery);
 	f.rssurl = rssurl.href
 
@@ -316,5 +316,3 @@ async function getSearchResults(f)
 	f.busy=false;
     }
 }
-
-

--- a/partials/commissie.html
+++ b/partials/commissie.html
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block extrameta %}
-<link rel="alternate" type="application/rss+xml" href="https://berthub.eu/tkconv/commissie/{{id}}/index.xml" title="OpenTK Feed voor {{naam}}" />
+<link rel="alternate" type="application/rss+xml" href="{{site_root}}/commissie/{{id}}/index.xml" title="OpenTK Feed voor {{naam}}" />
 {% endblock %}
 
 

--- a/partials/index.html
+++ b/partials/index.html
@@ -3,7 +3,7 @@
 {% block div %}{% endblock %}
 
 {% block extrameta %}
-<link rel="alternate" type="application/rss+xml" href="https://berthub.eu/tkconv/index.xml" title="OpenTK Meest recente parlementaire documenten" />
+<link rel="alternate" type="application/rss+xml" href="{{site_root}}/index.xml" title="OpenTK Meest recente parlementaire documenten" />
 {% endblock %}
 {% block customheader %}
 <form action="./search.html">

--- a/partials/mijn.html
+++ b/partials/mijn.html
@@ -15,7 +15,7 @@ selected: '1 dag'
 
 {% block extrameta %}
 {% if exists("timsi") %}
-<link rel="alternate" type="application/rss+xml" href="https://berthub.eu/tkconv/{{timsi}}/index.xml" title="OpenTK Jouw monitors RSS" />
+<link rel="alternate" type="application/rss+xml" href="{{site_root}}/{{timsi}}/index.xml" title="OpenTK Jouw monitors RSS" />
 {% endif %}
 {% endblock %}
 
@@ -29,7 +29,7 @@ selected: '1 dag'
 {% block customheader %}
 <h1>Mijn OpenTK 
 {% if exists("timsi") %}
-<a href="https://berthub.eu/tkconv/{{timsi}}/index.xml"><img src="Generic_Feed-icon.svg"></a>
+<a href="{{site_root}}/{{timsi}}/index.xml"><img src="Generic_Feed-icon.svg"></a>
 {% endif %}
 </h1>
 {% endblock %}

--- a/partials/search.html
+++ b/partials/search.html
@@ -11,6 +11,7 @@ busy: false,
 haveMonitor: false,
 rssurl: '',
 monitorId: '',
+siteRoot: '{{site_root}}',
 kind: 'zoek'
 }" x-init="init($data);"
 {% endblock %}
@@ -21,7 +22,7 @@ kind: 'zoek'
 {% endblock %}
 
 {% block extrameta %}
-<link rel="alternate" type="application/rss+xml" href="https://berthub.eu/tkconv/search/index.xml?q={{q}}" title="OpenTK zoek RSS" />
+<link rel="alternate" type="application/rss+xml" href="{{site_root}}/search/index.xml?q={{q}}" title="OpenTK zoek RSS" />
 {% endblock %}
 
 {% block customheader %}

--- a/tkserv.cc
+++ b/tkserv.cc
@@ -5,6 +5,7 @@
 #include <fmt/os.h>
 #include <fmt/chrono.h>
 #include <fmt/ranges.h>
+#include <cstdlib>
 #include <iostream>
 #include <map>
 #include "httplib.h"
@@ -50,11 +51,24 @@ void bulkEscape(nlohmann::json& j)
   });
 }
 
+static string getSiteRoot()
+{
+  static const string siteRoot = []() {
+    if(const char* env = getenv("SITE_ROOT"); env && *env)
+      return string(env);
+    throw runtime_error("SITE_ROOT must be set");
+  }();
+
+  return siteRoot;
+}
+
 class InjaData : public inja::json
 {
 public:
   explicit InjaData(inja::json data = inja::json::object()) : inja::json(std::move(data))
-  {}
+  {
+    (*this)["site_root"] = getSiteRoot();
+  }
 };
 
 static string getReasonableJPEG(const std::string& id)
@@ -459,8 +473,7 @@ int main(int argc, char** argv)
   sws.d_svr.set_keep_alive_max_count(1); 
   sws.d_svr.set_keep_alive_timeout(1);
   sws.standardFunctions();
-  addTkUserManagement(sws, "10.0.0.2", "opentk@hubertnet.nl", "https://berthub.eu/tkconv");
-  //  addTkUserManagement(sws, "10.0.0.2", "opentk@hubertnet.nl", "http://127.0.0.1:8089");
+  addTkUserManagement(sws, "10.0.0.2", "opentk@hubertnet.nl", getSiteRoot());
   
   
   if(args.is_used("--rnd-admin-password")) {
@@ -558,11 +571,11 @@ int main(int argc, char** argv)
     auto nums=sqlw->queryT("select nummer from Document where datum like ?", {year});
     string resp;
     for(auto& n : nums) {
-      resp += fmt::format("https://berthub.eu/tkconv/document.html?nummer={}\n", get<string>(n["nummer"]));
+      resp += fmt::format("{}/document.html?nummer={}\n", getSiteRoot(), get<string>(n["nummer"]));
     }
     nums=sqlw->queryT("select vergadering.id from vergadering,verslag where vergaderingid=vergadering.id and status != 'Casco' and datum like ? group by vergadering.id", {year});
     for(auto& n : nums) {
-      resp += fmt::format("https://berthub.eu/tkconv/verslag.html?vergaderingid={}\n", get<string>(n["id"]));
+      resp += fmt::format("{}/verslag.html?vergaderingid={}\n", getSiteRoot(), get<string>(n["id"]));
     }
     
     res.set_content(resp, "text/plain");
@@ -587,11 +600,11 @@ int main(int argc, char** argv)
     auto nums=sqlw->queryT("select nummer from Document where datum >= ? and datum <= ?", {fromDate, toDate});
     string resp;
     for(auto& n : nums) {
-      resp += fmt::format("https://berthub.eu/tkconv/document.html?nummer={}\n", get<string>(n["nummer"]));
+      resp += fmt::format("{}/document.html?nummer={}\n", getSiteRoot(), get<string>(n["nummer"]));
     }
     nums=sqlw->queryT("select vergadering.id from vergadering,verslag where vergaderingid=vergadering.id and status != 'Casco' and datum >= ? and datum <= ? group by vergadering.id", {fromDate, toDate});
     for(auto& n : nums) {
-      resp += fmt::format("https://berthub.eu/tkconv/verslag.html?vergaderingid={}\n", get<string>(n["id"]));
+      resp += fmt::format("{}/verslag.html?vergaderingid={}\n", getSiteRoot(), get<string>(n["id"]));
     }
     
     res.set_content(resp, "text/plain");
@@ -620,11 +633,11 @@ int main(int argc, char** argv)
     auto nums=sqlw->queryT("select nummer from Document where datum like ?", {year});
     string resp;
     for(auto& n : nums) {
-      resp += fmt::format("https://berthub.eu/tkconv/document.html?nummer={}\n", get<string>(n["nummer"]));
+      resp += fmt::format("{}/document.html?nummer={}\n", getSiteRoot(), get<string>(n["nummer"]));
     }
     nums = sqlw->queryT("select vergadering.id from vergadering,verslag where vergaderingid=vergadering.id and status != 'Casco' and datum like ? group by vergadering.id", {year});
     for(auto& n : nums) {
-      resp += fmt::format("https://berthub.eu/tkconv/verslag.html?vergaderingid={}\n", get<string>(n["id"]));
+      resp += fmt::format("{}/verslag.html?vergaderingid={}\n", getSiteRoot(), get<string>(n["id"]));
     }
     res.set_content(resp, "text/plain");
   });
@@ -711,7 +724,7 @@ int main(int argc, char** argv)
     
     j["og"]["title"] = (string)lid[0]["roepnaam"] + " "+tv + (string)lid[0]["achternaam"];
     j["og"]["description"] = (string)lid[0]["functie"];
-    j["og"]["imageurl"] = "https://berthub.eu/tkconv/personphoto/"+to_string(nummer);
+    j["og"]["imageurl"] = getSiteRoot()+"/personphoto/"+to_string(nummer);
 
     inja::Environment e;
     e.set_html_autoescape(true);

--- a/tkserv.cc
+++ b/tkserv.cc
@@ -50,6 +50,13 @@ void bulkEscape(nlohmann::json& j)
   });
 }
 
+class InjaData : public inja::json
+{
+public:
+  explicit InjaData(inja::json data = inja::json::object()) : inja::json(std::move(data))
+  {}
+};
+
 static string getReasonableJPEG(const std::string& id)
 {
   if(isPresentNonEmpty(id, "photoscache", ".jpg") && cacheIsNewer(id, "photoscache", ".jpg", "photos")) {
@@ -663,7 +670,7 @@ int main(int argc, char** argv)
 
     lid[0]["afkorting"] = getPartyFromNumber(sqlw.get(), nummer);
     string persoonId = lid[0]["id"];
-    nlohmann::json j = nlohmann::json::object();
+    InjaData j;
     j["meta"] = lid[0];
 
     auto zaken = packResultsJson(sqlw->queryT("select substr(zaak.gestartOp,0,11) gestartOp, zaak.onderwerp, zaak.nummer, zaak.id from zaakactor,zaak where persoonid=? and relatie='Indiener' and zaak.id=zaakid order by gestartop desc, nummer desc", {persoonId}));
@@ -714,7 +721,7 @@ int main(int argc, char** argv)
   });
 
   sws.wrapGet({}, "/mijn.html", [&tp](auto& cr) {
-    nlohmann::json data;
+    InjaData data;
     data["pagemeta"]["title"]="Mijn";
     data["og"]["title"] = "Mijn";
     data["og"]["description"] = "Mijn";
@@ -733,7 +740,7 @@ int main(int argc, char** argv)
 
   sws.wrapGet({}, "/search.html", [&tp](auto& cr) {
     string q = cr.req.get_param_value("q");
-    nlohmann::json data;
+    InjaData data;
     data["pagemeta"]["title"]="Zoek naar "+htmlEscape(q);
     data["og"]["title"] = "Zoek naar "+htmlEscape(q);
     data["og"]["description"] = "Zoek naar "+htmlEscape(q);
@@ -747,7 +754,7 @@ int main(int argc, char** argv)
 
 
   sws.wrapGet({}, "/personen.html", [&tp](auto& cr) {
-    nlohmann::json data;
+    InjaData data;
     data["pagemeta"]["title"]="Alle personen";
     data["og"]["title"] = "Alle personen";
     data["og"]["description"] = "Alle personen";
@@ -792,7 +799,7 @@ int main(int argc, char** argv)
       res.status = 404;
       return;
     }
-    nlohmann::json data; 
+    InjaData data;
     inja::Environment e;
     e.set_html_autoescape(true);
     
@@ -810,7 +817,7 @@ int main(int argc, char** argv)
   
   sws.d_svr.Get("/zaak.html", [&tp](const httplib::Request &req, httplib::Response &res) {
     string nummer = req.get_param_value("nummer");
-    nlohmann::json z = nlohmann::json::object();
+    InjaData z;
     auto sqlw = tp.getLease();
     auto zaken = sqlw->queryT("select *, substr(gestartOp, 0, 11) gestartOp from zaak where nummer=?", {nummer});
     if(zaken.empty()) {
@@ -1041,7 +1048,7 @@ int main(int argc, char** argv)
     sws.d_svr.Get("/"+name+"(/?.*)", [&tp, name, file, q](const httplib::Request &req, httplib::Response &res) {
       inja::Environment e;
       e.set_html_autoescape(true);
-      nlohmann::json data;
+      InjaData data;
       if(!q.empty())
 	data["data"] = packResultsJson(tp.getLease()->queryT(q));
       
@@ -1081,7 +1088,7 @@ int main(int argc, char** argv)
     bool onlyRegeringsstukken = req.has_param("onlyRegeringsstukken") && req.get_param_value("onlyRegeringsstukken") != "0";
 
     string dlim = fmt::format("{:%Y-%m-%d}", fmt::localtime(time(0) - 8*86400));
-    nlohmann::json data;
+    InjaData data;
     auto recentDocs = packResultsJson(sqlw->queryT("select Document.datum datum, Document.nummer nummer, Document.onderwerp onderwerp, Document.titel titel, Document.soort soort, Document.bijgewerkt bijgewerkt, ZaakActor.naam naam, ZaakActor.afkorting afkorting from Document left join Link on link.van = document.id left join zaak on zaak.id = link.naar left join  ZaakActor on ZaakActor.zaakId = zaak.id and relatie = 'Voortouwcommissie' where  Document.soort != 'Sprekerslijst' and datum > ? and (? or Document.soort in ('Brief regering', 'Antwoord schriftelijke vragen', 'Voorstel van wet', 'Memorie van toelichting', 'Antwoord schriftelijke vragen (nader)')) and +bronDocument='' order by datum desc, bijgewerkt desc",
 						  {dlim, !onlyRegeringsstukken}));
 
@@ -1210,7 +1217,7 @@ int main(int argc, char** argv)
     
     inja::Environment e;
     e.set_html_autoescape(true);
-    nlohmann::json data;
+    InjaData data;
     data["pagemeta"]["title"]="OpenTK - Toezeggingen";
     data["og"]["title"] = "OpenTK - Toezeggingen";
     data["og"]["description"] = "Toezeggingen van het kabinet";
@@ -1229,7 +1236,7 @@ int main(int argc, char** argv)
     string fractie=req.get_param_value("fractie");
     string ministerie=req.get_param_value("ministerie");
     
-    nlohmann::json data;
+    InjaData data;
     auto lease = tp.getLease();
 
     auto ovragen =  packResultsJson(lease->queryT("select openvragen.*, zaak.gestartOp, aantal, json_group_array(naam) as namen, max(naam) filter (where relatie='Indiener') as indiener, json_group_array(relatie) as relaties, json_group_array(zaakactor.functie) as functies, max(persoon.nummer) filter (where relatie='Indiener') as indiennummer from openvragen,zaakactor,zaak left join persoon on persoon.id=persoonid left join SchriftelijkeVraagStat on SchriftelijkeVraagStat.documentNummer = openvragen.docunummer where zaakactor.zaakid = openvragen.id and zaak.nummer=openvragen.nummer group by openvragen.id order by gestartOp desc"));
@@ -1413,7 +1420,7 @@ int main(int argc, char** argv)
 
 
   sws.d_svr.Get("/besluiten.html", [&tp](const httplib::Request &req, httplib::Response &res) {
-    nlohmann::json data;
+    InjaData data;
     string dlim = fmt::format("{:%Y-%m-%d}", fmt::localtime(time(0) - 8*86400));
     auto besluiten =  packResultsJson(tp.getLease()->queryT("select activiteit.datum, activiteit.nummer anummer, zaak.nummer znummer, agendapuntZaakBesluitVolgorde volg, besluit.status,agendapunt.onderwerp aonderwerp, zaak.onderwerp zonderwerp, naam indiener, besluit.tekst from besluit,agendapunt,activiteit,zaak left join zaakactor on zaakactor.zaakid = zaak.id and relatie='Indiener' where besluit.agendapuntid = agendapunt.id and activiteit.id = agendapunt.activiteitid and zaak.id = besluit.zaakid and datum > ? order by datum asc,agendapuntZaakBesluitVolgorde asc", {dlim}));
 
@@ -1436,7 +1443,7 @@ int main(int argc, char** argv)
   // this is still alpine.js based though somehow!
   sws.d_svr.Get("/activiteit.html", [&tp](const httplib::Request &req, httplib::Response &res) {
     string nummer=req.get_param_value("nummer");
-    nlohmann::json data;
+    InjaData data;
     auto act = packResultsJson(tp.getLease()->queryT("select * from Activiteit where nummer=?", {nummer}));
 
     if(act.empty()) {
@@ -1495,7 +1502,7 @@ int main(int argc, char** argv)
       else
 	a["marker"] = "";
     }
-    nlohmann::json data = nlohmann::json::object();
+    InjaData data;
     data["data"] = acts;
     data["meta"]["commissie"] = commissie; 
     data["meta"]["commies"] = nlohmann::json::array();
@@ -1541,7 +1548,7 @@ int main(int argc, char** argv)
       a["bijgewerkt"] = ((string)a["bijgewerkt"]).substr(0, 10);
       commies.insert({a["voortouwAfkorting"], a["voortouwNaam"]});
     }
-    nlohmann::json data = nlohmann::json::object();
+    InjaData data;
     data["data"] = acts;
     data["meta"]["commissie"] = req.get_param_value("commissie");
     data["meta"]["commies"] = nlohmann::json::array();
@@ -1578,7 +1585,7 @@ int main(int argc, char** argv)
     
     inja::Environment e;
     e.set_html_autoescape(true);
-    nlohmann::json data;
+    InjaData data;
     data["pagemeta"]["title"]= eget(deets[0], "naam");
     data["og"]["title"] = eget(deets[0], "naam");
     data["og"]["description"] = eget(deets[0], "naam");
@@ -1595,7 +1602,7 @@ int main(int argc, char** argv)
     string toevoeging=req.get_param_value("toevoeging").c_str();
     auto sqlw = tp.getLease();
     auto docs = packResultsJson(sqlw->queryT("select document.nummer docnummer,* from Document,Kamerstukdossier where kamerstukdossier.nummer=? and kamerstukdossier.toevoeging=? and Document.kamerstukdossierid = kamerstukdossier.id order by volgnummer desc", {nummer, toevoeging}));
-    nlohmann::json data = nlohmann::json::object();
+    InjaData data;
     for(auto& d : docs) {
       d["datum"] = ((string)d["datum"]).substr(0, 10);
     }
@@ -1636,7 +1643,7 @@ int main(int argc, char** argv)
       return;
     }
 
-    nlohmann::json data = nlohmann::json::object();
+    InjaData data;
     auto ret=sqlw->queryT("select Document.*, DocumentVersie.externeidentifier, DocumentVersie.versienummer, DocumentVersie.extensie from Document left join DocumentVersie on DocumentVersie.documentId = Document.id where nummer=? limit 1", {nummer});
     if(ret.empty()) {
       res.set_content("Found nothing in document.html!!", "text/plain");
@@ -1865,7 +1872,7 @@ int main(int argc, char** argv)
       return;
     }
 
-    nlohmann::json data = verslagen[0];
+    InjaData data(verslagen[0]);
     
     // 2024-09-19T12:19:10.3141655Z
     string updated = data["updated"];
@@ -1893,7 +1900,7 @@ int main(int argc, char** argv)
     auto tmp = getVerslagen(tp.getLease().get(), 2*365);
     inja::Environment e;
     e.set_html_autoescape(true);
-    nlohmann::json data;
+    InjaData data;
     data["recenteVerslagen"] = packResultsJson(tmp);
     data["pagemeta"]["title"]="Verslagen – OpenTK";
     data["og"]["title"] = "Recente verslagen";
@@ -1964,7 +1971,7 @@ int main(int argc, char** argv)
       }
       break;
     }
-    nlohmann::json data;
+    InjaData data;
     data["stemmingen"] = stemmingen;
     data["weken"] = weeks;
     inja::Environment e;
@@ -2165,7 +2172,7 @@ int main(int argc, char** argv)
   sws.d_svr.set_error_handler([](const auto& req, auto& res) {
     inja::Environment e;
     e.set_html_autoescape(true);
-    nlohmann::json data;
+    InjaData data;
     data["pagemeta"]["title"]="Error – OpenTK";
     data["og"]["title"] = fmt::format("Error {} {} @ {}", res.status, httplib::status_message(res.status), time(0));
     data["error"] = data["og"]["title"];

--- a/users.cc
+++ b/users.cc
@@ -7,7 +7,8 @@
 #include <fmt/chrono.h>
 using namespace std;
 
-static auto prepRSS(auto& doc, const std::string& title, const std::string& desc)
+static auto prepRSS(auto& doc, const std::string& title, const std::string& desc,
+		    const std::string& baseUrl)
 {
   doc.append_attribute("standalone") = "yes";
   doc.append_attribute("version") = "1.0";
@@ -20,7 +21,7 @@ static auto prepRSS(auto& doc, const std::string& title, const std::string& desc
   pugi::xml_node channel = rss.append_child("channel");
   channel.append_child("title").append_child(pugi::node_pcdata).set_value(title.c_str());
   channel.append_child("description").append_child(pugi::node_pcdata).set_value(desc.c_str());
-  channel.append_child("link").append_child(pugi::node_pcdata).set_value("https://berthub.eu/tkconv/");
+  channel.append_child("link").append_child(pugi::node_pcdata).set_value((baseUrl + "/").c_str());
   channel.append_child("generator").append_child(pugi::node_pcdata).set_value("OpenTK");
   return channel;
 }
@@ -300,7 +301,7 @@ Goed inzicht in ons parlement is belangrijk, soms omdat er dingen in het nieuws 
   */
   
 
-  sws.wrapGet({}, "/index.xml", [](auto& cr) {
+  sws.wrapGet({}, "/index.xml", [baseUrl](auto& cr) {
     pugi::xml_document doc;
 
     string dlim = fmt::format("{:%Y-%m-%d}", fmt::localtime(time(0) - 8*86400));
@@ -318,7 +319,8 @@ Goed inzicht in ons parlement is belangrijk, soms omdat er dingen in het nieuws 
       latest = getTstamp(maxbw);
     }
     string date = fmt::format("{:%a, %d %b %Y %H:%M:%S %z}", fmt::localtime(latest));
-    pugi::xml_node channel = prepRSS(doc, "Hoofd OpenTK feed", "Meest recente kamerdocumenten");
+    pugi::xml_node channel = prepRSS(doc, "Hoofd OpenTK feed",
+				     "Meest recente kamerdocumenten", baseUrl);
     channel.append_child("lastBuildDate").append_child(pugi::node_pcdata).set_value(date.c_str());
 
     for(const auto& r : rows) {
@@ -332,7 +334,7 @@ Goed inzicht in ons parlement is belangrijk, soms omdat er dingen in het nieuws 
 
       
       item.append_child("link").append_child(pugi::node_pcdata).set_value(
-									  fmt::format("https://berthub.eu/tkconv/document.html?nummer={}", eget(r,"nummer")).c_str());
+									  fmt::format("{}/document.html?nummer={}", baseUrl, eget(r,"nummer")).c_str());
       item.append_child("guid").append_child(pugi::node_pcdata).set_value(("tkconv_"+eget(r, "nummer")).c_str());
 
 
@@ -353,7 +355,7 @@ Goed inzicht in ons parlement is belangrijk, soms omdat er dingen in het nieuws 
   });
 
   // https://berthub.eu/tkconv/search.html?q=bert+hubert&twomonths=false&soorten=alles
-  sws.wrapGet({}, "/search/index.xml", [](auto& cr) {
+  sws.wrapGet({}, "/search/index.xml", [baseUrl](auto& cr) {
     string q = convertToSQLiteFTS5(cr.req.get_param_value("q"));
     string categorie;
 
@@ -365,7 +367,9 @@ Goed inzicht in ons parlement is belangrijk, soms omdat er dingen in het nieuws 
     auto matches = sh.search(q, {"Document"});
     cout<<"Have "<<matches.size()<<" matches\n";
     pugi::xml_document doc;
-    pugi::xml_node channel = prepRSS(doc, "Zoek RSS naar " +q, "Documenten gematched door zoekstring "+q);
+    pugi::xml_node channel = prepRSS(doc, "Zoek RSS naar " +q,
+				     "Documenten gematched door zoekstring "+q,
+				     baseUrl);
     
     bool first = true;
     
@@ -386,7 +390,7 @@ Goed inzicht in ons parlement is belangrijk, soms omdat er dingen in het nieuws 
 
       
       item.append_child("link").append_child(pugi::node_pcdata).set_value(
-									  fmt::format("https://berthub.eu/tkconv/document.html?nummer={}", eget(r,"nummer")).c_str());
+									  fmt::format("{}/document.html?nummer={}", baseUrl, eget(r,"nummer")).c_str());
 	item.append_child("guid").append_child(pugi::node_pcdata).set_value(("tkconv_"+eget(r, "nummer")).c_str());
 
       // 2024-12-06T06:01:10.2530000
@@ -414,7 +418,7 @@ Goed inzicht in ons parlement is belangrijk, soms omdat er dingen in het nieuws 
     return make_pair<string,string>(str.str(), "application/xml");
   });
   
-  sws.wrapGet({}, "/:timsi/index.xml", [](auto& cr) {
+  sws.wrapGet({}, "/:timsi/index.xml", [baseUrl](auto& cr) {
     string timsi = cr.req.path_params.at("timsi");
     cout<<"Called for timsi "<< timsi <<endl;
 
@@ -423,7 +427,9 @@ Goed inzicht in ons parlement is belangrijk, soms omdat er dingen in het nieuws 
     cout<<"Got "<<docids.size()<<" docids\n";
     
     pugi::xml_document doc;
-    pugi::xml_node channel = prepRSS(doc, "Monitor RSS", "Documenten gematched door jouw monitors");
+    pugi::xml_node channel = prepRSS(doc, "Monitor RSS",
+				     "Documenten gematched door jouw monitors",
+				     baseUrl);
     
     bool first = true;
 
@@ -445,7 +451,7 @@ Goed inzicht in ons parlement is belangrijk, soms omdat er dingen in het nieuws 
 
       
       item.append_child("link").append_child(pugi::node_pcdata).set_value(
-									  fmt::format("https://berthub.eu/tkconv/document.html?nummer={}", eget(r,"nummer")).c_str());
+									  fmt::format("{}/document.html?nummer={}", baseUrl, eget(r,"nummer")).c_str());
       item.append_child("guid").append_child(pugi::node_pcdata).set_value(("tkconv_"+eget(r, "nummer")).c_str());
 
       // 2024-12-06T06:01:10.2530000
@@ -473,7 +479,7 @@ Goed inzicht in ons parlement is belangrijk, soms omdat er dingen in het nieuws 
     return make_pair<string,string>(str.str(), "application/xml");
   });
 
-  sws.wrapGet({}, "/commissie/:commissieid/index.xml", [](auto& cr) {
+  sws.wrapGet({}, "/commissie/:commissieid/index.xml", [baseUrl](auto& cr) {
     string commissieid = cr.req.path_params.at("commissieid");
     cout<<"Called for commissieid "<<commissieid<<endl;
     string dlim = fmt::format("{:%Y-%m-%d}", fmt::localtime(time(0) - 100*86400));
@@ -487,7 +493,8 @@ Goed inzicht in ons parlement is belangrijk, soms omdat er dingen in het nieuws 
     string naam = eget(comm[0], "naam");
     
     pugi::xml_document doc;
-    pugi::xml_node channel = prepRSS(doc, "OpenTK: "+ naam + " RSS", "Documenten voor " + naam);
+    pugi::xml_node channel = prepRSS(doc, "OpenTK: "+ naam + " RSS",
+				     "Documenten voor " + naam, baseUrl);
     
     bool first = true;
 
@@ -501,7 +508,7 @@ Goed inzicht in ons parlement is belangrijk, soms omdat er dingen in het nieuws 
       
       item.append_child("description").append_child(pugi::node_pcdata).set_value(onderwerp.c_str());
       item.append_child("link").append_child(pugi::node_pcdata).set_value(
-									  fmt::format("https://berthub.eu/tkconv/document.html?nummer={}", eget(r,"nummer")).c_str());
+									  fmt::format("{}/document.html?nummer={}", baseUrl, eget(r,"nummer")).c_str());
       item.append_child("guid").append_child(pugi::node_pcdata).set_value(("tkconv_"+eget(r, "nummer")).c_str());
       // 2024-12-06T06:01:10.2530000
       string pubDate = eget(r, "bijgewerkt");


### PR DESCRIPTION
Docker defaults to https://berthub.eu/tkconv so production should not be affected. That's assuming you're actually using Docker on production, otherwise a better default would be `http://127.0.0.1:8089`. 

A refactor commit first introduces `class InjaData : public inja::json` so we have the contructor set `site_root`, which all the partials then use.

RSS and other generated absolute URLs now also use SITE_ROOT.

`html/logic.js` is not generated from a template, so instead we set
`siteRoot` in `partials/search.html` which the `js` then uses.

Email links were intentionally not updated, because I can't test it.

README is updated with a `SITE_ROOT` hint for local development.