### PR TITLE
Fix tkindex als oo.sqlite3 afwezig is

### DIFF
--- a/tkindex.cc
+++ b/tkindex.cc
@@ -98,7 +98,12 @@ int main(int argc, char** argv)
   }
   cout<<"Limit for documents: "<<limit<<endl;
   SQLiteWriter todo("tk.sqlite3", SQLWFlag::ReadOnly);
-  todo.query("ATTACH DATABASE 'oo.sqlite3' as oo");
+  try {
+    todo.query("ATTACH DATABASE 'oo.sqlite3' as oo");
+  }
+  catch(exception& e) {
+    fmt::print("Error attaching oo.sqlite3, perhaps it does not yet exist? Error was: {}\n", e.what());
+  }
   
   std::regex dregex(R"(\d{4}-\d{2}-\d{2})");
   if(!regex_match(limit, dregex)) {
@@ -129,10 +134,15 @@ int main(int argc, char** argv)
   auto wantPersoonGeschenk = todo.queryT("select persoongeschenk.id id, omschrijving, datum, roepnaam, tussenvoegsel, achternaam,persoongeschenk.bijgewerkt from PersoonGeschenk,Persoon where persoon.id = persoonId");
   fmt::print("There are {} persoongeschenken in the tk database that need to be in the index\n", wantPersoonGeschenk.size());
 
-  auto wantOO = todo.queryT("select id, titel, openbaarmakingsdatum datum, verantwoordelijke, grootte contentLength, mutatiedatumtijd bijgewerkt, 'OODocument' category, omschrijvingen as onderwerp from OODocument where datum > ? and verantwoordelijke != 'Tweede Kamer' and documentsoorten not like '%Kamerbrief%' and contentType != 'application/x-zip-compressed'", {limit});
-  fmt::print("There are {} OODocuments in the tk database that need to be in the index\n", wantOO.size());
-  
-  
+  decltype(wantDocs) wantOO;
+  try {
+    wantOO = todo.queryT("select id, titel, openbaarmakingsdatum datum, verantwoordelijke, grootte contentLength, mutatiedatumtijd bijgewerkt, 'OODocument' category, omschrijvingen as onderwerp from OODocument where datum > ? and verantwoordelijke != 'Tweede Kamer' and documentsoorten not like '%Kamerbrief%' and contentType != 'application/x-zip-compressed'", {limit});
+    fmt::print("There are {} OODocuments in the tk database that need to be in the index\n", wantOO.size());
+  }
+  catch(exception& e) {
+    fmt::print("Error retrieving OODocuments, perhaps the oo.sqlite3 database does not yet exist? Error was: {}\n", e.what());
+  }
+
   // query voor verslagen is ingewikkeld want we willen alleen de nieuwste versie indexeren
   // en sterker nog alle oude versies wissen
   fmt::print("Getting verslagen since {}\n", limit);


### PR DESCRIPTION
Volgens de `README.md` hoeft `ooget` en `oopull` momenteel niet gerund te worden. In dat geval bestaat `oo.sqlite3` echter niet, en daardoor werkt  `tkindex` momenteel niet correct. Helaas werkt `ooget` momenteel ook niet correct (zie hieronder). Dit is een simpele exception handling om ervoor te zorgen dat `tkindex` in ieder geval werkt als de `oo.sqlite3` database mist.

Ik heb ook even gekeken waarom `ooget` momenteel niet lijkt te werken. In

https://github.com/berthubert/tkconv/blob/0712e1e111697a07378fcee682690ba64ac62c97/ooget.cc#L247

en 

https://github.com/berthubert/tkconv/blob/0712e1e111697a07378fcee682690ba64ac62c97/ooget.cc#L251

worden momenteel nieuwe tabellen aangemaakt, maar die definities zijn niet correct. Latere regels (L341-349 en L464-480) doen vermoeden waat de correcte definities moeten zijn. Maar ik heb dit hier niet aangepast omdat ik dat niet zeker weet. Na de correcte definities werkt het in principe wel, maar begint het proces vanaf 1900, en ik ben daar nog niet verder ingedoken om het werkend te krijgen.