### PR TITLE
Add links back into app from scanner list on mijn.html

### DIFF
--- a/partials/mijn.html
+++ b/partials/mijn.html
@@ -183,7 +183,7 @@ selected: "1 dag"}' x-init="doMijnInit($data)"
       </thead>
       <tbody>
       <template x-for="m in monitors">
-	<tr><td x-text="m.type"></td><td x-text="m.description"></td>
+	<tr><td x-text="m.type"></td><td><a x-bind:href="m.href" x-text="m.description"></a></td>
 	  <td><span x-text="m.cnt"></span></td>
 	  <td>
 	    <select x-model="m.interval" @change="updateInterval($data, m.id, m.interval)"> 

--- a/scanmon.hh
+++ b/scanmon.hh
@@ -22,6 +22,7 @@ struct ScannerHit
 struct Scanner
 {
   virtual std::string describe(SQLiteWriter& sqlw) = 0;
+  virtual std::string getLink() = 0;
   virtual std::string getType() = 0;
   virtual std::vector<ScannerHit> get(SQLiteWriter& sqlw) = 0;
   auto getRow(SQLiteWriter& sqlw, const std::string& id)
@@ -86,6 +87,12 @@ struct CommissieScanner : Scanner
     }
     return naam;
   }
+
+  std::string getLink() override
+  {
+    return "commissie.html?id=" + d_commissieid;
+  }
+
   std::string d_commissieid;
 };
 
@@ -147,6 +154,12 @@ struct PersoonScanner : Scanner
     }
     return "Persoon " + naam;
   }
+
+  std::string getLink() override
+  {
+    return "persoon.html?nummer=" + d_nummer;
+  }
+
   std::string d_nummer;
 };
 
@@ -181,6 +194,12 @@ struct ActiviteitScanner : Scanner
     }
     return "Activiteit " + d_nummer+": "+ onderwerp;
   }
+
+  std::string getLink() override
+  {
+    return "activiteit.html?nummer=" + d_nummer;
+  }
+
   std::string d_nummer;
 };
 
@@ -228,6 +247,12 @@ struct ZaakScanner : Scanner
     }
     return "Zaak " + d_nummer+": "+ onderwerp;
   }
+
+  std::string getLink() override
+  {
+    return "zaak.html?nummer=" + d_nummer;
+  }
+
   std::string d_nummer;
 };
 
@@ -263,6 +288,12 @@ struct KsdScanner : Scanner
     }
     return "Kamerstukdossier " + d_nummer+ " " +d_toevoeging+": "+ onderwerp;
   }
+
+  std::string getLink() override
+  {
+    return "ksd.html?ksd=" + d_nummer + "&toevoeging=" + d_toevoeging;
+  }
+
   std::string d_nummer, d_toevoeging;
 };
 
@@ -317,6 +348,19 @@ struct ToezeggingenScanner : Scanner
     else
       return "???";
   }
+
+  std::string getLink() override
+  {
+    if(d_fractie.empty() && d_voortouwAfkorting.empty())
+      return "toezeggingen.html";
+    else if(!d_fractie.empty())
+      return "toezeggingen.html?fractie="+d_fractie;
+    else if(!d_voortouwAfkorting.empty())
+      return "toezeggingen.html?commissie="+d_voortouwAfkorting;
+    else
+      return "toezeggingen.html";
+  }
+
   std::string d_fractie, d_voortouwAfkorting;
 };
 
@@ -342,6 +386,13 @@ struct OODocumentVerantwoordelijkeScanner : Scanner
   {
     return "Open.overheid.nl documenten van "+d_verantwoordelijke;
   }
+
+  std::string getLink() override
+  {
+    // no way yet to link to specific verantwoordelijke
+    return "oods.html";
+  }
+
   std::string d_verantwoordelijke;
 };
 
@@ -371,6 +422,11 @@ struct GeschenkScanner : Scanner
   {
     return "Geschenken";
   }
+
+  std::string getLink() override
+  {
+    return "geschenken.html";
+  }
 };
 #endif
 
@@ -385,6 +441,12 @@ struct ZoekScanner : Scanner
   std::string describe(SQLiteWriter& sqlw) override;
   std::string d_query;
   std::string d_categorie;
+
+  std::string getLink() override
+  {
+    return "search.html?q=" + d_query;
+  }
+
 };
 
 extern std::map<std::string, decltype(&ZaakScanner::make)> g_scanmakers;

--- a/users.cc
+++ b/users.cc
@@ -317,8 +317,10 @@ void addTkUserManagement(SimpleWebSystem& sws, const std::string& mailserver,
     for(auto& [id, sc] : scanners) {
       auto& [ptr, count] = sc;
       nlohmann::json jmon;
-      jmon["description"] = ptr->describe(cr.tp.getLease().get());
+      auto sqlw = cr.tp.getLease();
+      jmon["description"] = ptr->describe(sqlw.get());
       jmon["type"] = ptr->getType();
+      jmon["href"] = ptr->getLink();
       jmon["id"] = id;
       jmon["cnt"] = count;
       jmon["interval"] = ptr->d_interval;


### PR DESCRIPTION
This makes it so that the descriptions on mijn.html link back into the application. Where possible, the links go to the specific query that is being monitored.

<img width="743" height="498" alt="2026-05-24 11 25 21 localhost b865477a6105" src="https://github.com/user-attachments/assets/d52e4135-02fc-455e-b1b7-a54daa059d4f" />

The same getLink call could be used in the HTML email that is sent by tkbot, but this is not yet done.

Idea from https://github.com/berthubert/tkconv/issues/117