### PR TITLE
Move title, opengraph metadata rendering to template partials

### DIFF
--- a/partials/activiteit.html
+++ b/partials/activiteit.html
@@ -1,4 +1,6 @@
 {% extends "base.html" %}
+{% block title %}Activiteit{% endblock %}
+
 {% block div %}
 id="recent-docs" x-data="{
 nummer: '',

--- a/partials/activiteit.html
+++ b/partials/activiteit.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Activiteit{% endblock %}
 {% block og.title %}{{ onderwerp }}{% endblock %}
+{% block og.description %}{{ datum }}: {{ onderwerp }}{% endblock %}
 
 {% block div %}
 id="recent-docs" x-data="{

--- a/partials/activiteit.html
+++ b/partials/activiteit.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Activiteit{% endblock %}
+{% block og.title %}{{ onderwerp }}{% endblock %}
 
 {% block div %}
 id="recent-docs" x-data="{

--- a/partials/activiteiten.html
+++ b/partials/activiteiten.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}Activiteiten{% endblock %}
 
 {% block main %}
 <h4>Recente en toekomstige activiteiten

--- a/partials/activiteiten.html
+++ b/partials/activiteiten.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Activiteiten{% endblock %}
 {% block og.title %}Activiteiten{% endblock %}
+{% block og.description %}Activiteiten Tweede Kamer{% endblock %}
 
 {% block main %}
 <h4>Recente en toekomstige activiteiten

--- a/partials/activiteiten.html
+++ b/partials/activiteiten.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Activiteiten{% endblock %}
+{% block og.title %}Activiteiten{% endblock %}
 
 {% block main %}
 <h4>Recente en toekomstige activiteiten

--- a/partials/base.html
+++ b/partials/base.html
@@ -6,7 +6,7 @@
     <meta property='og:title' content='{{ og.title }}'>
     <meta property='og:description' content='{{ og.description }}'>
     <meta property='og:type' content='article'>
-    <meta property='og:image' content='{{og.imageurl}}'>
+    <meta property='og:image' content='{{default(og.imageurl,"")}}'>
     {% block extrameta %} {% endblock %}
     <link rel='stylesheet' href='pico.min.css' />
     <style>

--- a/partials/base.html
+++ b/partials/base.html
@@ -3,7 +3,7 @@
   <head>
     <title>{% block title %}{% endblock %} – OpenTK</title>
     <meta charset="utf-8">
-    <meta property='og:title' content='{{ og.title }}'>
+    <meta property='og:title' content='{% block og.title %}{% endblock %}'>
     <meta property='og:description' content='{{ og.description }}'>
     <meta property='og:type' content='article'>
     <meta property='og:image' content='{{default(og.imageurl,"")}}'>

--- a/partials/base.html
+++ b/partials/base.html
@@ -4,9 +4,8 @@
     <title>{% block title %}{% endblock %} – OpenTK</title>
     <meta charset="utf-8">
     <meta property='og:title' content='{% block og.title %}{% endblock %}'>
-    <meta property='og:description' content='{{ og.description }}'>
+    <meta property='og:description' content='{% block og.description %}{% endblock %}'>
     <meta property='og:type' content='article'>
-    <meta property='og:image' content='{{default(og.imageurl,"")}}'>
     {% block extrameta %} {% endblock %}
     <link rel='stylesheet' href='pico.min.css' />
     <style>

--- a/partials/base.html
+++ b/partials/base.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>{{ pagemeta.title }}</title>
+    <title>{% block title %}{% endblock %} – OpenTK</title>
     <meta charset="utf-8">
     <meta property='og:title' content='{{ og.title }}'>
     <meta property='og:description' content='{{ og.description }}'>

--- a/partials/besluiten.html
+++ b/partials/besluiten.html
@@ -1,4 +1,6 @@
 {% extends "base.html" %}
+{% block title %}Besluiten{% endblock %}
+
 {% block div %}
 {% endblock %}
 

--- a/partials/besluiten.html
+++ b/partials/besluiten.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Besluiten{% endblock %}
+{% block og.title %}Recente en toekomstige besluiten{% endblock %}
 
 {% block main %}
 <h4>Recente en toekomstige besluiten</h4>

--- a/partials/besluiten.html
+++ b/partials/besluiten.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Besluiten{% endblock %}
 {% block og.title %}Recente en toekomstige besluiten{% endblock %}
+{% block og.description %}Recente en toekomstige besluiten in de Tweede Kamer{% endblock %}
 
 {% block main %}
 <h4>Recente en toekomstige besluiten</h4>

--- a/partials/besluiten.html
+++ b/partials/besluiten.html
@@ -1,9 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Besluiten{% endblock %}
 
-{% block div %}
-{% endblock %}
-
 {% block main %}
 <h4>Recente en toekomstige besluiten</h4>
 <table class="striped">

--- a/partials/commissie.html
+++ b/partials/commissie.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}{{ naam }}{% endblock %}
 {% block og.title %}{{ naam }}{% endblock %}
+{% block og.description %}{{ naam }}{% endblock %}
 
 {% block javascript %}
 <script defer src="user.js"></script>

--- a/partials/commissie.html
+++ b/partials/commissie.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}{{ naam }}{% endblock %}
+{% block og.title %}{{ naam }}{% endblock %}
 
 {% block javascript %}
 <script defer src="user.js"></script>

--- a/partials/commissie.html
+++ b/partials/commissie.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}{{ naam }}{% endblock %}
 
 {% block javascript %}
 <script defer src="user.js"></script>

--- a/partials/commissies.html
+++ b/partials/commissies.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Commissies{% endblock %}
+{% block og.title %}Commissies van de Tweede Kamer{% endblock %}
 
 {% block main %}
 <h4>Commissies</h4>

--- a/partials/commissies.html
+++ b/partials/commissies.html
@@ -1,9 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Commissies{% endblock %}
 
-{% block div %}
-{% endblock %}
-
 {% block javascript %}
 {% endblock %}
 

--- a/partials/commissies.html
+++ b/partials/commissies.html
@@ -1,4 +1,6 @@
 {% extends "base.html" %}
+{% block title %}Commissies{% endblock %}
+
 {% block div %}
 {% endblock %}
 

--- a/partials/commissies.html
+++ b/partials/commissies.html
@@ -1,9 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Commissies{% endblock %}
 
-{% block javascript %}
-{% endblock %}
-
 {% block main %}
 <h4>Commissies</h4>
 <h5>Actief</h5>

--- a/partials/error.html
+++ b/partials/error.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Error{% endblock %}
 {% block og.title %}{{ error }}{% endblock %}
+{% block og.description %}Een TKConv error: {{ error }}{% endblock %}
 
 {% block main %}
 <hr>

--- a/partials/error.html
+++ b/partials/error.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Error{% endblock %}
+{% block og.title %}{{ error }}{% endblock %}
 
 {% block main %}
 <hr>

--- a/partials/error.html
+++ b/partials/error.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}Error{% endblock %}
 
 {% block main %}
 <hr>

--- a/partials/geschenken.html
+++ b/partials/geschenken.html
@@ -1,4 +1,6 @@
 {% extends "base.html" %}
+{% block title %}Geschenken{% endblock %}
+
 {% block div %}{% endblock %}
 
 {% block main %}

--- a/partials/geschenken.html
+++ b/partials/geschenken.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Geschenken{% endblock %}
+{% block og.title %}Geschenken ontvangen door leden van de Tweede Kamer{% endblock %}
 
 {% block main %}
 <h4>Geschenken</h4>

--- a/partials/geschenken.html
+++ b/partials/geschenken.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Geschenken{% endblock %}
 
-{% block div %}{% endblock %}
-
 {% block main %}
 <h4>Geschenken</h4>
     <table class="striped">

--- a/partials/getorig.html
+++ b/partials/getorig.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}{{ meta.onderwerp }}{% endblock %}
 
 {% block javascript %}
 <script defer src="user.js"></script>

--- a/partials/getorig.html
+++ b/partials/getorig.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}{{ meta.onderwerp }}{% endblock %}
+{% block og.title %}{{ meta.onderwerp }}{% endblock %}
 
 {% block javascript %}
 <script defer src="user.js"></script>

--- a/partials/getorig.html
+++ b/partials/getorig.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}{{ meta.onderwerp }}{% endblock %}
 {% block og.title %}{{ meta.onderwerp }}{% endblock %}
+{% block og.description %}{{ meta.titel }} {{ meta.onderwerp }}{% endblock %}
 
 {% block javascript %}
 <script defer src="user.js"></script>

--- a/partials/index.html
+++ b/partials/index.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Hoofdpagina{% endblock %}
 
-{% block javascript %}{% endblock %}
-
 {% block extrameta %}
 <link rel="alternate" type="application/rss+xml" href="https://berthub.eu/tkconv/index.xml" title="OpenTK Meest recente parlementaire documenten" />
 {% endblock %}

--- a/partials/index.html
+++ b/partials/index.html
@@ -1,4 +1,6 @@
 {% extends "base.html" %}
+{% block title %}Hoofdpagina{% endblock %}
+
 {% block javascript %}{% endblock %}
 {% block div %}{% endblock %}
 

--- a/partials/index.html
+++ b/partials/index.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Hoofdpagina{% endblock %}
 {% block og.title %}Recente documenten{% endblock %}
+{% block og.description %}Recente documenten uit de Tweede Kamer{% endblock %}
 
 {% block extrameta %}
 <link rel="alternate" type="application/rss+xml" href="https://berthub.eu/tkconv/index.xml" title="OpenTK Meest recente parlementaire documenten" />

--- a/partials/index.html
+++ b/partials/index.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Hoofdpagina{% endblock %}
+{% block og.title %}Recente documenten{% endblock %}
 
 {% block extrameta %}
 <link rel="alternate" type="application/rss+xml" href="https://berthub.eu/tkconv/index.xml" title="OpenTK Meest recente parlementaire documenten" />

--- a/partials/index.html
+++ b/partials/index.html
@@ -2,7 +2,6 @@
 {% block title %}Hoofdpagina{% endblock %}
 
 {% block javascript %}{% endblock %}
-{% block div %}{% endblock %}
 
 {% block extrameta %}
 <link rel="alternate" type="application/rss+xml" href="https://berthub.eu/tkconv/index.xml" title="OpenTK Meest recente parlementaire documenten" />

--- a/partials/kamerleden.html
+++ b/partials/kamerleden.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Kamerleden{% endblock %}
+{% block og.title %}Leden van de Tweede Kamer{% endblock %}
 
 {% block main %}
 

--- a/partials/kamerleden.html
+++ b/partials/kamerleden.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}Kamerleden{% endblock %}
 
 {% block main %}
 

--- a/partials/kamerstukdossiers.html
+++ b/partials/kamerstukdossiers.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Kamerstukdossiers{% endblock %}
+{% block og.title %}Kamerstukdossiers{% endblock %}
 
 {% block div %}
 x-data="{  kamerstukdossiers: []  }" x-init="getGenKSD('recent-kamerstukdossiers', 'kamerstukdossiers', $data);"

--- a/partials/kamerstukdossiers.html
+++ b/partials/kamerstukdossiers.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}Kamerstukdossiers{% endblock %}
 
 {% block div %}
 x-data="{  kamerstukdossiers: []  }" x-init="getGenKSD('recent-kamerstukdossiers', 'kamerstukdossiers', $data);"

--- a/partials/ksd.html
+++ b/partials/ksd.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}{{ meta.titel }}{% endblock %}
 
 {% block javascript %}
 <script defer src="user.js"></script>

--- a/partials/ksd.html
+++ b/partials/ksd.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}{{ meta.titel }}{% endblock %}
+{% block og.title %}{{ meta.titel }}{% endblock %}
 
 {% block javascript %}
 <script defer src="user.js"></script>

--- a/partials/ksd.html
+++ b/partials/ksd.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}{{ meta.titel }}{% endblock %}
 {% block og.title %}{{ meta.titel }}{% endblock %}
+{% block og.description %}{{ meta.titel }}{% endblock %}
 
 {% block javascript %}
 <script defer src="user.js"></script>

--- a/partials/mijn.html
+++ b/partials/mijn.html
@@ -1,4 +1,6 @@
 {% extends "base.html" %}
+{% block title %}Mijn{% endblock %}
+
 {% block div %}
 id="recent-docs" x-data='{
 email: "",

--- a/partials/mijn.html
+++ b/partials/mijn.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Mijn{% endblock %}
+{% block og.title %}Mijn{% endblock %}
 
 {% block div %}
 id="recent-docs" x-data='{

--- a/partials/mijn.html
+++ b/partials/mijn.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Mijn{% endblock %}
 {% block og.title %}Mijn{% endblock %}
+{% block og.description %}Mijn{% endblock %}
 
 {% block div %}
 id="recent-docs" x-data='{

--- a/partials/ongeplande-activiteiten.html
+++ b/partials/ongeplande-activiteiten.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}Ongeplande activiteiten{% endblock %}
 
 {% block main %}
 <h4>Nog ongeplande activiteiten

--- a/partials/ongeplande-activiteiten.html
+++ b/partials/ongeplande-activiteiten.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Ongeplande activiteiten{% endblock %}
 {% block og.title %}Ongeplande activiteiten{% endblock %}
+{% block og.description %}Ongeplande activiteiten Tweede Kamer{% endblock %}
 
 {% block main %}
 <h4>Nog ongeplande activiteiten

--- a/partials/ongeplande-activiteiten.html
+++ b/partials/ongeplande-activiteiten.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Ongeplande activiteiten{% endblock %}
+{% block og.title %}Ongeplande activiteiten{% endblock %}
 
 {% block main %}
 <h4>Nog ongeplande activiteiten

--- a/partials/oo.html
+++ b/partials/oo.html
@@ -1,9 +1,6 @@
 {% extends "base.html" %}
 {% block title %}{{ titel }}{% endblock %}
 
-{% block div %}
-{% endblock %}
-
 {% block javascript %}
 {% endblock %}
 

--- a/partials/oo.html
+++ b/partials/oo.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}{{ titel }}{% endblock %}
+{% block og.title %}{{ titel }}{% endblock %}
 
 {% block main %}
 <hgroup>

--- a/partials/oo.html
+++ b/partials/oo.html
@@ -1,4 +1,6 @@
 {% extends "base.html" %}
+{% block title %}{{ titel }}{% endblock %}
+
 {% block div %}
 {% endblock %}
 

--- a/partials/oo.html
+++ b/partials/oo.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}{{ titel }}{% endblock %}
 {% block og.title %}{{ titel }}{% endblock %}
+{% block og.description %}{{ mutatiedatumtijd }} {{ titel }}{% endblock %}
 
 {% block main %}
 <hgroup>

--- a/partials/oo.html
+++ b/partials/oo.html
@@ -1,10 +1,6 @@
 {% extends "base.html" %}
 {% block title %}{{ titel }}{% endblock %}
 
-{% block javascript %}
-{% endblock %}
-
-
 {% block main %}
 <hgroup>
 <h1>{{ titel }}</h1>

--- a/partials/oods.html
+++ b/partials/oods.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Alle open.overheid.nl documenten{% endblock %}
 {% block og.title %}Alle open.overheid.nl documenten{% endblock %}
+{% block og.description %}Alle open.overheid.nl documenten{% endblock %}
 
 {% block div %}
 x-data="{

--- a/partials/oods.html
+++ b/partials/oods.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}Alle open.overheid.nl documenten{% endblock %}
 
 {% block div %}
 x-data="{

--- a/partials/oods.html
+++ b/partials/oods.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Alle open.overheid.nl documenten{% endblock %}
+{% block og.title %}Alle open.overheid.nl documenten{% endblock %}
 
 {% block div %}
 x-data="{

--- a/partials/open-vragen.html
+++ b/partials/open-vragen.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Open vragen{% endblock %}
 {% block og.title %}Open vragen{% endblock %}
+{% block og.description %}Open vragen uit de Tweede Kamer{% endblock %}
 
 {% block customheader %}
 <p>{{ aantalvragen }} open vragen, in {{ length(openVragen) }} documenten (waarvan <font color="#ff0000">{{ totlaatzonderuitstel }}</font> te laat zonder uitstel)</p>

--- a/partials/open-vragen.html
+++ b/partials/open-vragen.html
@@ -1,4 +1,6 @@
 {% extends "base.html" %}
+{% block title %}Open vragen{% endblock %}
+
 {% block div %}
 {% endblock %}
 {% block javascript %}

--- a/partials/open-vragen.html
+++ b/partials/open-vragen.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Open vragen{% endblock %}
+{% block og.title %}Open vragen{% endblock %}
 
 {% block customheader %}
 <p>{{ aantalvragen }} open vragen, in {{ length(openVragen) }} documenten (waarvan <font color="#ff0000">{{ totlaatzonderuitstel }}</font> te laat zonder uitstel)</p>

--- a/partials/open-vragen.html
+++ b/partials/open-vragen.html
@@ -1,9 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Open vragen{% endblock %}
 
-{% block javascript %}
-{% endblock %}
-
 {% block customheader %}
 <p>{{ aantalvragen }} open vragen, in {{ length(openVragen) }} documenten (waarvan <font color="#ff0000">{{ totlaatzonderuitstel }}</font> te laat zonder uitstel)</p>
 {% endblock %}

--- a/partials/open-vragen.html
+++ b/partials/open-vragen.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Open vragen{% endblock %}
 
-{% block div %}
-{% endblock %}
 {% block javascript %}
 {% endblock %}
 

--- a/partials/personen.html
+++ b/partials/personen.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}Alle personen{% endblock %}
 
 {% block main %}
 <h4>Kamerleden en veel voormalige kamerleden</h4>

--- a/partials/personen.html
+++ b/partials/personen.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Alle personen{% endblock %}
 {% block og.title %}Alle personen{% endblock %}
+{% block og.description %}Alle personen{% endblock %}
 
 {% block main %}
 <h4>Kamerleden en veel voormalige kamerleden</h4>

--- a/partials/personen.html
+++ b/partials/personen.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Alle personen{% endblock %}
+{% block og.title %}Alle personen{% endblock %}
 
 {% block main %}
 <h4>Kamerleden en veel voormalige kamerleden</h4>

--- a/partials/persoon.html
+++ b/partials/persoon.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Kamerlid{% endblock %}
+{% block og.title %}{{meta.roepnaam}} {% if meta.tussenvoegsel != "" %}{{meta.tussenvoegsel}} {% endif %}{{meta.achternaam}}{% endblock %}
 
 {% block div %}
 x-data="{

--- a/partials/persoon.html
+++ b/partials/persoon.html
@@ -1,6 +1,10 @@
 {% extends "base.html" %}
 {% block title %}Kamerlid{% endblock %}
 {% block og.title %}{{meta.roepnaam}} {% if meta.tussenvoegsel != "" %}{{meta.tussenvoegsel}} {% endif %}{{meta.achternaam}}{% endblock %}
+{% block og.description %}{{meta.functie}}{% endblock %}
+{% block extrameta %}
+    <meta property='og:image' content='https://berthub.eu/tkconv/personphoto/{{meta.nummer}}'>
+{% endblock %}
 
 {% block div %}
 x-data="{

--- a/partials/persoon.html
+++ b/partials/persoon.html
@@ -1,4 +1,6 @@
 {% extends "base.html" %}
+{% block title %}Kamerlid{% endblock %}
+
 {% block div %}
 x-data="{
 haveMonitor: false,

--- a/partials/search.html
+++ b/partials/search.html
@@ -1,4 +1,6 @@
 {% extends "base.html" %}
+{% block title %}Zoek naar {{h}}{% endblock %}
+
 {% block div %}
 x-data="{
 foundDocs: [],

--- a/partials/search.html
+++ b/partials/search.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}{% if h != "" %}Zoek naar {{h}}{% else %}Zoeken{% endif %}{% endblock %}
 {% block og.title %}{% if h != "" %}Zoek naar {{h}}{% else %}Zoeken{% endif %}{% endblock %}
+{% block og.description %}{% if h != "" %}Zoek naar {{h}}{% else %}Zoeken{% endif %}{% endblock %}
 
 {% block div %}
 x-data="{

--- a/partials/search.html
+++ b/partials/search.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% block title %}Zoek naar {{h}}{% endblock %}
+{% block title %}{% if h != "" %}Zoek naar {{h}}{% else %}Zoeken{% endif %}{% endblock %}
+{% block og.title %}{% if h != "" %}Zoek naar {{h}}{% else %}Zoeken{% endif %}{% endblock %}
 
 {% block div %}
 x-data="{

--- a/partials/stemmingen.html
+++ b/partials/stemmingen.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Stemmingen{% endblock %}
 {% block og.title %}Stemmingen{% endblock %}
+{% block og.description %}Stemmingen{% endblock %}
 
 {% block main %}
 <h4>Recente stemmingen (afgelopen {{weken}} weken)</h4>

--- a/partials/stemmingen.html
+++ b/partials/stemmingen.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}Stemmingen{% endblock %}
 
 {% block div %}
 {% endblock %}

--- a/partials/stemmingen.html
+++ b/partials/stemmingen.html
@@ -1,10 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Stemmingen{% endblock %}
 
-{% block div %}
-{% endblock %}
-
-
 {% block main %}
 <h4>Recente stemmingen (afgelopen {{weken}} weken)</h4>
 <table class="striped">

--- a/partials/stemmingen.html
+++ b/partials/stemmingen.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Stemmingen{% endblock %}
+{% block og.title %}Stemmingen{% endblock %}
 
 {% block main %}
 <h4>Recente stemmingen (afgelopen {{weken}} weken)</h4>

--- a/partials/toezegging.html
+++ b/partials/toezegging.html
@@ -1,9 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Toezegging {{toez.tnummer}}{% endblock %}
 
-{% block javascript %}
-{% endblock %}
-
 {% block customheader %}
 <p></p>
 <h4>Toezegging {{toez.tnummer}} ({{toez.status}})</h4>

--- a/partials/toezegging.html
+++ b/partials/toezegging.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Toezegging {{toez.tnummer}}{% endblock %}
+{% block og.title %}Toezegging {{toez.tnummer}}{% endblock %}
 
 {% block customheader %}
 <p></p>

--- a/partials/toezegging.html
+++ b/partials/toezegging.html
@@ -1,4 +1,6 @@
 {% extends "base.html" %}
+{% block title %}Toezegging {{toez.tnummer}}{% endblock %}
+
 {% block div %}
 {% endblock %}
 

--- a/partials/toezegging.html
+++ b/partials/toezegging.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Toezegging {{toez.tnummer}}{% endblock %}
 {% block og.title %}Toezegging {{toez.tnummer}}{% endblock %}
+{% block og.description %}{{toez.tekst}}{% endblock %}
 
 {% block customheader %}
 <p></p>

--- a/partials/toezegging.html
+++ b/partials/toezegging.html
@@ -1,9 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Toezegging {{toez.tnummer}}{% endblock %}
 
-{% block div %}
-{% endblock %}
-
 {% block javascript %}
 {% endblock %}
 

--- a/partials/toezeggingen.html
+++ b/partials/toezeggingen.html
@@ -1,4 +1,6 @@
 {% extends "base.html" %}
+{% block title %}Toezeggingen{% endblock %}
+
 {% block div %}
 x-data="{
 haveMonitor: false,

--- a/partials/toezeggingen.html
+++ b/partials/toezeggingen.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Toezeggingen{% endblock %}
 {% block og.title %}Toezeggingen{% endblock %}
+{% block og.description %}Toezeggingen van het kabinet{% endblock %}
 
 {% block div %}
 x-data="{

--- a/partials/toezeggingen.html
+++ b/partials/toezeggingen.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Toezeggingen{% endblock %}
+{% block og.title %}Toezeggingen{% endblock %}
 
 {% block div %}
 x-data="{

--- a/partials/uitleg.html
+++ b/partials/uitleg.html
@@ -1,8 +1,7 @@
 {% extends "base.html" %}
+{% block title %}Uitleg en tips{% endblock %}
 
 {% block main %}
-
-
 <h4>Uitleg en tips</h4>
 In deze twee blog-posts staan uitleg met screenshots:
 <p>
@@ -55,4 +54,3 @@ Aarzel niet met het zetten van monitors - als een document meerdere malen matcht
 </p> 
 
 {% endblock %}
-	

--- a/partials/uitleg.html
+++ b/partials/uitleg.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Uitleg en tips{% endblock %}
+{% block og.title %}Uitleg en tips{% endblock %}
 
 {% block main %}
 <h4>Uitleg en tips</h4>

--- a/partials/verslag.html
+++ b/partials/verslag.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}{{titel}}{% endblock %}
+{% block og.title %}{{titel}}{% endblock %}
 
 {% block customheader %}
 <h5>Datum {{datum}}. Laatste update: {{updated}}</h5>

--- a/partials/verslag.html
+++ b/partials/verslag.html
@@ -1,9 +1,6 @@
 {% extends "base.html" %}
 {% block title %}{{titel}}{% endblock %}
 
-{% block javascript %}
-{% endblock %}
-
 {% block customheader %}
 <h5>Datum {{datum}}. Laatste update: {{updated}}</h5>
 <h5>{{zaal}}</h5>

--- a/partials/verslag.html
+++ b/partials/verslag.html
@@ -1,9 +1,6 @@
 {% extends "base.html" %}
 {% block title %}{{titel}}{% endblock %}
 
-{% block div %}
-{% endblock %}
-
 {% block javascript %}
 {% endblock %}
 

--- a/partials/verslag.html
+++ b/partials/verslag.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}{{titel}}{% endblock %}
 {% block og.title %}{{titel}}{% endblock %}
+{% block og.description %}{{updated}} {{titel}}{% endblock %}
 
 {% block customheader %}
 <h5>Datum {{datum}}. Laatste update: {{updated}}</h5>

--- a/partials/verslag.html
+++ b/partials/verslag.html
@@ -1,4 +1,6 @@
 {% extends "base.html" %}
+{% block title %}{{titel}}{% endblock %}
+
 {% block div %}
 {% endblock %}
 

--- a/partials/verslagen.html
+++ b/partials/verslagen.html
@@ -1,4 +1,6 @@
 {% extends "base.html" %}
+{% block title %}Verslagen{% endblock %}
+
 {% block main %}
 <h4>Verslagen</h4>
 <table class="striped">

--- a/partials/verslagen.html
+++ b/partials/verslagen.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Verslagen{% endblock %}
 {% block og.title %}Recente verslagen{% endblock %}
+{% block og.description %}Recente verslagen uit de Tweede Kamer{% endblock %}
 
 {% block main %}
 <h4>Verslagen</h4>

--- a/partials/verslagen.html
+++ b/partials/verslagen.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Verslagen{% endblock %}
+{% block og.title %}Recente verslagen{% endblock %}
 
 {% block main %}
 <h4>Verslagen</h4>

--- a/partials/zaak.html
+++ b/partials/zaak.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Zaak {{zaak.nummer}}{% endblock %}
 {% block og.title %}Zaak {{zaak.nummer} | {{zaak.onderwerp}}{% endblock %}
+{% block og.description %}Zaak {{zaak.nummer} | {{zaak.onderwerp}}{% endblock %}
 
 {% block div %}
 x-data="{

--- a/partials/zaak.html
+++ b/partials/zaak.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Zaak {{zaak.nummer}}{% endblock %}
+{% block og.title %}Zaak {{zaak.nummer} | {{zaak.onderwerp}}{% endblock %}
 
 {% block div %}
 x-data="{

--- a/partials/zaak.html
+++ b/partials/zaak.html
@@ -1,4 +1,6 @@
 {% extends "base.html" %}
+{% block title %}Zaak {{zaak.nummer}}{% endblock %}
+
 {% block div %}
 x-data="{
 haveMonitor: false,
@@ -7,7 +9,6 @@ nummer: '{{zaak.nummer}}',
 kind: 'zaak'
 }" x-init="checkMonitor($data)"
 {% endblock %}
-
 
 {% block javascript %}
 <script defer src="user.js"></script>

--- a/tkserv.cc
+++ b/tkserv.cc
@@ -705,9 +705,6 @@ int main(int argc, char** argv)
 
     j["openvragen"] = packResultsJson(sqlw->queryT("select substr(openvragen.gestartOp, 0, 11) sdatum, aantal, openvragen.* from openvragen,zaakactor,zaak,persoon left join SchriftelijkeVraagStat on SchriftelijkeVraagStat.documentNummer = openvragen.docunummer  where persoon.id=persoonid and zaak.id = openvragen.id and zaak.id = zaakactor.zaakid and relatie='Indiener' and persoon.id=? order by sdatum asc", {persoonId}));
 
-    j["og"]["description"] = (string)lid[0]["functie"];
-    j["og"]["imageurl"] = "https://berthub.eu/tkconv/personphoto/"+to_string(nummer);
-
     inja::Environment e;
     e.set_html_autoescape(true);
     
@@ -717,7 +714,6 @@ int main(int argc, char** argv)
 
   sws.wrapGet({}, "/mijn.html", [&tp](auto& cr) {
     nlohmann::json data;
-    data["og"]["description"] = "Mijn";
 
     inja::Environment e;
     e.set_html_autoescape(true);
@@ -736,7 +732,6 @@ int main(int argc, char** argv)
   sws.wrapGet({}, "/search.html", [&tp](auto& cr) {
     string q = cr.req.get_param_value("q");
     nlohmann::json data;
-    data["og"]["description"] = "Zoek naar "+htmlEscape(q);
     data["q"] = urlEscape(q);
     data["h"] = htmlEscape(q);
     inja::Environment e;
@@ -748,7 +743,6 @@ int main(int argc, char** argv)
 
   sws.wrapGet({}, "/personen.html", [&tp](auto& cr) {
     nlohmann::json data;
-    data["og"]["description"] = "Alle personen";
 
     auto personen = packResultsJson(tp.getLease()->queryT(R"(select min(van) voorheteerst, titels, persoon.nummer, roepnaam,tussenvoegsel,achternaam,json_group_array(distinct(afkorting)) fracties from persoon,fractiezetelpersoon,fractiezetel,fractie where  fractiezetelpersoon.persoonid = persoon.id and fractiezetelpersoon.fractiezetelid = fractiezetel.id and fractie.id=fractiezetel.fractieid group by persoon.id order by achternaam,roepnaam)"));
 
@@ -766,7 +760,6 @@ int main(int argc, char** argv)
 
   sws.wrapGet({}, "/oods.html", [&tp](auto& cr) {
     nlohmann::json data;
-    data["og"]["description"] = "Alle open.overheid.nl documenten";
 
     /*
       Selection criteria:
@@ -891,7 +884,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true);
     
-    data["og"]["description"] = eget(toez[0], "tekst");
     data["toez"]=packResultsJson(toez)[0];
     if(data["toez"]["pnummer"] != "")
       data["toez"]["pfractie"] = getPartyFromNumber(sqlw.get(), (int)data["toez"]["pnummer"]);
@@ -974,7 +966,6 @@ int main(int argc, char** argv)
     }
     z["adocs"] = adocs;
     // XXX agendapunt multi
-    z["og"]["description"] = "Zaak " + eget(zaken[0], "titel") + " | " + eget(zaken[0], "onderwerp");
 
     inja::Environment e;
     e.set_html_autoescape(true);
@@ -1135,8 +1126,6 @@ int main(int argc, char** argv)
       if(!q.empty())
 	data["data"] = packResultsJson(tp.getLease()->queryT(q));
       
-      data["og"]["description"] = name;
-
       res.set_content(e.render_file("./partials/"+file, data), "text/html");
     });
   };
@@ -1225,8 +1214,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true);
 
-    data["og"]["description"] = "Recente documenten uit de Tweede Kamer";
-    
     res.set_content(e.render_file("./partials/index.html", data), "text/html");
   });
 
@@ -1295,7 +1282,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true);
     nlohmann::json data;
-    data["og"]["description"] = "Toezeggingen van het kabinet";
     data["data"] = filtered;
     data["voortouw"] = commissie;
     data["fractie"] = fractie;
@@ -1446,8 +1432,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true);
 
-    data["og"]["description"] = "Open vragen uit de Tweede Kamer";
-
     res.set_content(e.render_file("./partials/open-vragen.html", data), "text/html");
   });
 
@@ -1503,8 +1487,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true);
 
-    data["og"]["description"] = "Recente en toekomstige besluiten in de Tweede Kamer";
-    
     res.set_content(e.render_file("./partials/besluiten.html", data), "text/html");
   });
   
@@ -1522,8 +1504,7 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true);
 
-    data["onderwerp"] = act[0]["onderwerp"];
-    data["og"]["description"] = (string)act[0]["datum"] + ": "+ (string)act[0]["onderwerp"];
+    data = act[0];
     
     res.set_content(e.render_file("./partials/activiteit.html", data), "text/html");
   });
@@ -1586,8 +1567,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(false); // NOTE WELL!
 
-    data["og"]["description"] = "Activiteiten Tweede Kamer";
-    
     res.set_content(e.render_file("./partials/activiteiten.html", data), "text/html");
   });
 
@@ -1628,8 +1607,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(false); // NOTE WELL!
 
-    data["og"]["description"] = "Ongeplande activiteiten Tweede Kamer";
-
     res.set_content(e.render_file("./partials/ongeplande-activiteiten.html", data), "text/html");
   });
 
@@ -1646,7 +1623,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true);
     nlohmann::json data;
-    data["og"]["description"] = eget(deets[0], "naam");
 
     data["id"] = id;
     data["naam"] = eget(deets[0], "naam");
@@ -1673,8 +1649,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true);
 
-    data["og"]["description"] = docs[0]["titel"];
-    
     res.set_content(e.render_file("./partials/ksd.html", data), "text/html");
   });
   
@@ -1877,8 +1851,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(false);
 
-    data["og"]["description"] = get<string>(ret[0]["titel"]) + " " +get<string>(ret[0]["onderwerp"]);
-
     bulkEscape(data); 
 
     if(!externeid.empty() && haveExternalIdFile(externeid)) {
@@ -1956,8 +1928,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(false); // XX 
 
-    data["og"]["description"] = (string)data["updated"] + " " + (string)data["titel"];
-
     bulkEscape(data); 
     data["htmlverslag"]=enrichHTML(getHtmlForDocument(data["id"], true), tp.getLease().get());
     res.set_content(e.render_file("./partials/verslag.html", data), "text/html");
@@ -2002,8 +1972,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(false); // XX 
 
-    data["og"]["description"] = (string)data["mutatiedatumtijd"] + " " + (string)data["titel"];
-
     bulkEscape(data); 
     //    data["htmlverslag"]="";
     res.set_content(e.render_file("./partials/oo.html", data), "text/html");
@@ -2016,7 +1984,6 @@ int main(int argc, char** argv)
     e.set_html_autoescape(true);
     nlohmann::json data;
     data["recenteVerslagen"] = packResultsJson(tmp);
-    data["og"]["description"] = "Recente verslagen uit de Tweede Kamer";
     
     res.set_content(e.render_file("./partials/verslagen.html", data), "text/html");
   });
@@ -2090,8 +2057,6 @@ int main(int argc, char** argv)
     data["weken"] = weeks;
     inja::Environment e;
     e.set_html_autoescape(true); 
-
-    data["og"]["description"] = "Stemmingen";
 
     res.set_content(e.render_file("./partials/stemmingen.html", data), "text/html");
   });
@@ -2290,7 +2255,6 @@ int main(int argc, char** argv)
     string error = fmt::format("Error {} {} @ {}", res.status, httplib::status_message(res.status), time(0));
     data["error"] = error;
       
-    data["og"]["description"] = "Een TKConv error: " + error;
     cout<<"Error: "<<req.path<<" '"<< error <<"'"<<endl;
     res.set_content(e.render_file("./partials/error.html", data), "text/html");
   });

--- a/tkserv.cc
+++ b/tkserv.cc
@@ -705,11 +705,6 @@ int main(int argc, char** argv)
 
     j["openvragen"] = packResultsJson(sqlw->queryT("select substr(openvragen.gestartOp, 0, 11) sdatum, aantal, openvragen.* from openvragen,zaakactor,zaak,persoon left join SchriftelijkeVraagStat on SchriftelijkeVraagStat.documentNummer = openvragen.docunummer  where persoon.id=persoonid and zaak.id = openvragen.id and zaak.id = zaakactor.zaakid and relatie='Indiener' and persoon.id=? order by sdatum asc", {persoonId}));
 
-    string tv = lid[0]["tussenvoegsel"];
-    if(!tv.empty())
-      tv += ' ';
-    
-    j["og"]["title"] = (string)lid[0]["roepnaam"] + " "+tv + (string)lid[0]["achternaam"];
     j["og"]["description"] = (string)lid[0]["functie"];
     j["og"]["imageurl"] = "https://berthub.eu/tkconv/personphoto/"+to_string(nummer);
 
@@ -722,7 +717,6 @@ int main(int argc, char** argv)
 
   sws.wrapGet({}, "/mijn.html", [&tp](auto& cr) {
     nlohmann::json data;
-    data["og"]["title"] = "Mijn";
     data["og"]["description"] = "Mijn";
 
     inja::Environment e;
@@ -742,7 +736,6 @@ int main(int argc, char** argv)
   sws.wrapGet({}, "/search.html", [&tp](auto& cr) {
     string q = cr.req.get_param_value("q");
     nlohmann::json data;
-    data["og"]["title"] = "Zoek naar "+htmlEscape(q);
     data["og"]["description"] = "Zoek naar "+htmlEscape(q);
     data["q"] = urlEscape(q);
     data["h"] = htmlEscape(q);
@@ -755,7 +748,6 @@ int main(int argc, char** argv)
 
   sws.wrapGet({}, "/personen.html", [&tp](auto& cr) {
     nlohmann::json data;
-    data["og"]["title"] = "Alle personen";
     data["og"]["description"] = "Alle personen";
 
     auto personen = packResultsJson(tp.getLease()->queryT(R"(select min(van) voorheteerst, titels, persoon.nummer, roepnaam,tussenvoegsel,achternaam,json_group_array(distinct(afkorting)) fracties from persoon,fractiezetelpersoon,fractiezetel,fractie where  fractiezetelpersoon.persoonid = persoon.id and fractiezetelpersoon.fractiezetelid = fractiezetel.id and fractie.id=fractiezetel.fractieid group by persoon.id order by achternaam,roepnaam)"));
@@ -774,7 +766,6 @@ int main(int argc, char** argv)
 
   sws.wrapGet({}, "/oods.html", [&tp](auto& cr) {
     nlohmann::json data;
-    data["og"]["title"] = "Alle open.overheid.nl documenten";
     data["og"]["description"] = "Alle open.overheid.nl documenten";
 
     /*
@@ -900,7 +891,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true);
     
-    data["og"]["title"] = "Toezegging "+nummer;
     data["og"]["description"] = eget(toez[0], "tekst");
     data["toez"]=packResultsJson(toez)[0];
     if(data["toez"]["pnummer"] != "")
@@ -984,7 +974,6 @@ int main(int argc, char** argv)
     }
     z["adocs"] = adocs;
     // XXX agendapunt multi
-    z["og"]["title"] = "Zaak " + nummer+" | " +  eget(zaken[0], "onderwerp");
     z["og"]["description"] = "Zaak " + eget(zaken[0], "titel") + " | " + eget(zaken[0], "onderwerp");
 
     inja::Environment e;
@@ -1146,7 +1135,6 @@ int main(int argc, char** argv)
       if(!q.empty())
 	data["data"] = packResultsJson(tp.getLease()->queryT(q));
       
-      data["og"]["title"] = name;
       data["og"]["description"] = name;
 
       res.set_content(e.render_file("./partials/"+file, data), "text/html");
@@ -1237,7 +1225,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true);
 
-    data["og"]["title"] = "Recente documenten";
     data["og"]["description"] = "Recente documenten uit de Tweede Kamer";
     
     res.set_content(e.render_file("./partials/index.html", data), "text/html");
@@ -1308,7 +1295,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true);
     nlohmann::json data;
-    data["og"]["title"] = "OpenTK - Toezeggingen";
     data["og"]["description"] = "Toezeggingen van het kabinet";
     data["data"] = filtered;
     data["voortouw"] = commissie;
@@ -1460,7 +1446,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true);
 
-    data["og"]["title"] = "Open vragen";
     data["og"]["description"] = "Open vragen uit de Tweede Kamer";
 
     res.set_content(e.render_file("./partials/open-vragen.html", data), "text/html");
@@ -1518,7 +1503,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true);
 
-    data["og"]["title"] = "Recente en toekomstige besluiten";
     data["og"]["description"] = "Recente en toekomstige besluiten in de Tweede Kamer";
     
     res.set_content(e.render_file("./partials/besluiten.html", data), "text/html");
@@ -1538,7 +1522,7 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true);
 
-    data["og"]["title"] = act[0]["onderwerp"];
+    data["onderwerp"] = act[0]["onderwerp"];
     data["og"]["description"] = (string)act[0]["datum"] + ": "+ (string)act[0]["onderwerp"];
     
     res.set_content(e.render_file("./partials/activiteit.html", data), "text/html");
@@ -1602,7 +1586,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(false); // NOTE WELL!
 
-    data["og"]["title"] = "Activiteiten";
     data["og"]["description"] = "Activiteiten Tweede Kamer";
     
     res.set_content(e.render_file("./partials/activiteiten.html", data), "text/html");
@@ -1645,7 +1628,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(false); // NOTE WELL!
 
-    data["og"]["title"] = "Ongeplande activiteiten";
     data["og"]["description"] = "Ongeplande activiteiten Tweede Kamer";
 
     res.set_content(e.render_file("./partials/ongeplande-activiteiten.html", data), "text/html");
@@ -1664,7 +1646,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true);
     nlohmann::json data;
-    data["og"]["title"] = eget(deets[0], "naam");
     data["og"]["description"] = eget(deets[0], "naam");
 
     data["id"] = id;
@@ -1692,7 +1673,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true);
 
-    data["og"]["title"] = docs[0]["titel"];
     data["og"]["description"] = docs[0]["titel"];
     
     res.set_content(e.render_file("./partials/ksd.html", data), "text/html");
@@ -1897,7 +1877,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(false);
 
-    data["og"]["title"] = get<string>(ret[0]["onderwerp"]);
     data["og"]["description"] = get<string>(ret[0]["titel"]) + " " +get<string>(ret[0]["onderwerp"]);
 
     bulkEscape(data); 
@@ -1977,7 +1956,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(false); // XX 
 
-    data["og"]["title"] = (string)data["titel"];
     data["og"]["description"] = (string)data["updated"] + " " + (string)data["titel"];
 
     bulkEscape(data); 
@@ -2024,7 +2002,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(false); // XX 
 
-    data["og"]["title"] = (string)data["titel"];
     data["og"]["description"] = (string)data["mutatiedatumtijd"] + " " + (string)data["titel"];
 
     bulkEscape(data); 
@@ -2039,7 +2016,6 @@ int main(int argc, char** argv)
     e.set_html_autoescape(true);
     nlohmann::json data;
     data["recenteVerslagen"] = packResultsJson(tmp);
-    data["og"]["title"] = "Recente verslagen";
     data["og"]["description"] = "Recente verslagen uit de Tweede Kamer";
     
     res.set_content(e.render_file("./partials/verslagen.html", data), "text/html");
@@ -2115,7 +2091,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true); 
 
-    data["og"]["title"] = "Stemmingen";
     data["og"]["description"] = "Stemmingen";
 
     res.set_content(e.render_file("./partials/stemmingen.html", data), "text/html");
@@ -2312,11 +2287,11 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true);
     nlohmann::json data;
-    data["og"]["title"] = fmt::format("Error {} {} @ {}", res.status, httplib::status_message(res.status), time(0));
-    data["error"] = data["og"]["title"];
+    string error = fmt::format("Error {} {} @ {}", res.status, httplib::status_message(res.status), time(0));
+    data["error"] = error;
       
-    data["og"]["description"] = "Een TKConv error: " + (string)data["error"];
-    cout<<"Error: "<<req.path<<" '"<< (string)data["error"] <<"'"<<endl;
+    data["og"]["description"] = "Een TKConv error: " + error;
+    cout<<"Error: "<<req.path<<" '"<< error <<"'"<<endl;
     res.set_content(e.render_file("./partials/error.html", data), "text/html");
   });
   

--- a/tkserv.cc
+++ b/tkserv.cc
@@ -705,7 +705,6 @@ int main(int argc, char** argv)
 
     j["openvragen"] = packResultsJson(sqlw->queryT("select substr(openvragen.gestartOp, 0, 11) sdatum, aantal, openvragen.* from openvragen,zaakactor,zaak,persoon left join SchriftelijkeVraagStat on SchriftelijkeVraagStat.documentNummer = openvragen.docunummer  where persoon.id=persoonid and zaak.id = openvragen.id and zaak.id = zaakactor.zaakid and relatie='Indiener' and persoon.id=? order by sdatum asc", {persoonId}));
 
-    j["pagemeta"]["title"]="Kamerlid";
     string tv = lid[0]["tussenvoegsel"];
     if(!tv.empty())
       tv += ' ';
@@ -723,7 +722,6 @@ int main(int argc, char** argv)
 
   sws.wrapGet({}, "/mijn.html", [&tp](auto& cr) {
     nlohmann::json data;
-    data["pagemeta"]["title"]="Mijn";
     data["og"]["title"] = "Mijn";
     data["og"]["description"] = "Mijn";
 
@@ -744,10 +742,10 @@ int main(int argc, char** argv)
   sws.wrapGet({}, "/search.html", [&tp](auto& cr) {
     string q = cr.req.get_param_value("q");
     nlohmann::json data;
-    data["pagemeta"]["title"]="Zoek naar "+htmlEscape(q);
     data["og"]["title"] = "Zoek naar "+htmlEscape(q);
     data["og"]["description"] = "Zoek naar "+htmlEscape(q);
     data["q"] = urlEscape(q);
+    data["h"] = htmlEscape(q);
     inja::Environment e;
     e.set_html_autoescape(false); // !!
       
@@ -757,7 +755,6 @@ int main(int argc, char** argv)
 
   sws.wrapGet({}, "/personen.html", [&tp](auto& cr) {
     nlohmann::json data;
-    data["pagemeta"]["title"]="Alle personen";
     data["og"]["title"] = "Alle personen";
     data["og"]["description"] = "Alle personen";
 
@@ -777,7 +774,6 @@ int main(int argc, char** argv)
 
   sws.wrapGet({}, "/oods.html", [&tp](auto& cr) {
     nlohmann::json data;
-    data["pagemeta"]["title"]="Alle open.overheid.nl documenten";
     data["og"]["title"] = "Alle open.overheid.nl documenten";
     data["og"]["description"] = "Alle open.overheid.nl documenten";
 
@@ -904,7 +900,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true);
     
-    data["pagemeta"]["title"]="Toezegging " + nummer;
     data["og"]["title"] = "Toezegging "+nummer;
     data["og"]["description"] = eget(toez[0], "tekst");
     data["toez"]=packResultsJson(toez)[0];
@@ -989,7 +984,6 @@ int main(int argc, char** argv)
     }
     z["adocs"] = adocs;
     // XXX agendapunt multi
-    z["pagemeta"]["title"]="Zaak "+nummer;
     z["og"]["title"] = "Zaak " + nummer+" | " +  eget(zaken[0], "onderwerp");
     z["og"]["description"] = "Zaak " + eget(zaken[0], "titel") + " | " + eget(zaken[0], "onderwerp");
 
@@ -1152,7 +1146,6 @@ int main(int argc, char** argv)
       if(!q.empty())
 	data["data"] = packResultsJson(tp.getLease()->queryT(q));
       
-      data["pagemeta"]["title"]="";
       data["og"]["title"] = name;
       data["og"]["description"] = name;
 
@@ -1244,7 +1237,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true);
 
-    data["pagemeta"]["title"]="Hoofdpagina – OpenTK";
     data["og"]["title"] = "Recente documenten";
     data["og"]["description"] = "Recente documenten uit de Tweede Kamer";
     
@@ -1316,7 +1308,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true);
     nlohmann::json data;
-    data["pagemeta"]["title"]="OpenTK - Toezeggingen";
     data["og"]["title"] = "OpenTK - Toezeggingen";
     data["og"]["description"] = "Toezeggingen van het kabinet";
     data["data"] = filtered;
@@ -1469,7 +1460,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true);
 
-    data["pagemeta"]["title"]="Open Vragen – OpenTK";
     data["og"]["title"] = "Open vragen";
     data["og"]["description"] = "Open vragen uit de Tweede Kamer";
 
@@ -1528,7 +1518,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true);
 
-    data["pagemeta"]["title"]="Besluiten – OpenTK";
     data["og"]["title"] = "Recente en toekomstige besluiten";
     data["og"]["description"] = "Recente en toekomstige besluiten in de Tweede Kamer";
     
@@ -1549,7 +1538,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true);
 
-    data["pagemeta"]["title"]="Activiteit – OpenTK";
     data["og"]["title"] = act[0]["onderwerp"];
     data["og"]["description"] = (string)act[0]["datum"] + ": "+ (string)act[0]["onderwerp"];
     
@@ -1614,7 +1602,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(false); // NOTE WELL!
 
-    data["pagemeta"]["title"]="Activiteiten – OpenTK";
     data["og"]["title"] = "Activiteiten";
     data["og"]["description"] = "Activiteiten Tweede Kamer";
     
@@ -1658,7 +1645,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(false); // NOTE WELL!
 
-    data["pagemeta"]["title"]="Ongeplande activiteiten – OpenTK";
     data["og"]["title"] = "Ongeplande activiteiten";
     data["og"]["description"] = "Ongeplande activiteiten Tweede Kamer";
 
@@ -1678,7 +1664,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true);
     nlohmann::json data;
-    data["pagemeta"]["title"]= eget(deets[0], "naam");
     data["og"]["title"] = eget(deets[0], "naam");
     data["og"]["description"] = eget(deets[0], "naam");
 
@@ -1707,7 +1692,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true);
 
-    data["pagemeta"]["title"]="";
     data["og"]["title"] = docs[0]["titel"];
     data["og"]["description"] = docs[0]["titel"];
     
@@ -1913,7 +1897,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(false);
 
-    data["pagemeta"]["title"]=get<string>(ret[0]["onderwerp"]);
     data["og"]["title"] = get<string>(ret[0]["onderwerp"]);
     data["og"]["description"] = get<string>(ret[0]["titel"]) + " " +get<string>(ret[0]["onderwerp"]);
 
@@ -1994,7 +1977,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(false); // XX 
 
-    data["pagemeta"]["title"]=(string)data["titel"];
     data["og"]["title"] = (string)data["titel"];
     data["og"]["description"] = (string)data["updated"] + " " + (string)data["titel"];
 
@@ -2042,7 +2024,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(false); // XX 
 
-    data["pagemeta"]["title"]=(string)data["titel"];
     data["og"]["title"] = (string)data["titel"];
     data["og"]["description"] = (string)data["mutatiedatumtijd"] + " " + (string)data["titel"];
 
@@ -2058,7 +2039,6 @@ int main(int argc, char** argv)
     e.set_html_autoescape(true);
     nlohmann::json data;
     data["recenteVerslagen"] = packResultsJson(tmp);
-    data["pagemeta"]["title"]="Verslagen – OpenTK";
     data["og"]["title"] = "Recente verslagen";
     data["og"]["description"] = "Recente verslagen uit de Tweede Kamer";
     
@@ -2135,7 +2115,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true); 
 
-    data["pagemeta"]["title"]="Stemmingen – OpenTK";
     data["og"]["title"] = "Stemmingen";
     data["og"]["description"] = "Stemmingen";
 
@@ -2333,7 +2312,6 @@ int main(int argc, char** argv)
     inja::Environment e;
     e.set_html_autoescape(true);
     nlohmann::json data;
-    data["pagemeta"]["title"]="Error – OpenTK";
     data["og"]["title"] = fmt::format("Error {} {} @ {}", res.status, httplib::status_message(res.status), time(0));
     data["error"] = data["og"]["title"];
       

--- a/tkserv.cc
+++ b/tkserv.cc
@@ -726,7 +726,6 @@ int main(int argc, char** argv)
     data["pagemeta"]["title"]="Mijn";
     data["og"]["title"] = "Mijn";
     data["og"]["description"] = "Mijn";
-    data["og"]["imageurl"] = "";
 
     inja::Environment e;
     e.set_html_autoescape(true);
@@ -748,7 +747,6 @@ int main(int argc, char** argv)
     data["pagemeta"]["title"]="Zoek naar "+htmlEscape(q);
     data["og"]["title"] = "Zoek naar "+htmlEscape(q);
     data["og"]["description"] = "Zoek naar "+htmlEscape(q);
-    data["og"]["imageurl"] = "";
     data["q"] = urlEscape(q);
     inja::Environment e;
     e.set_html_autoescape(false); // !!
@@ -762,7 +760,6 @@ int main(int argc, char** argv)
     data["pagemeta"]["title"]="Alle personen";
     data["og"]["title"] = "Alle personen";
     data["og"]["description"] = "Alle personen";
-    data["og"]["imageurl"] = "";
 
     auto personen = packResultsJson(tp.getLease()->queryT(R"(select min(van) voorheteerst, titels, persoon.nummer, roepnaam,tussenvoegsel,achternaam,json_group_array(distinct(afkorting)) fracties from persoon,fractiezetelpersoon,fractiezetel,fractie where  fractiezetelpersoon.persoonid = persoon.id and fractiezetelpersoon.fractiezetelid = fractiezetel.id and fractie.id=fractiezetel.fractieid group by persoon.id order by achternaam,roepnaam)"));
 
@@ -783,7 +780,6 @@ int main(int argc, char** argv)
     data["pagemeta"]["title"]="Alle open.overheid.nl documenten";
     data["og"]["title"] = "Alle open.overheid.nl documenten";
     data["og"]["description"] = "Alle open.overheid.nl documenten";
-    data["og"]["imageurl"] = "";
 
     /*
       Selection criteria:
@@ -911,7 +907,6 @@ int main(int argc, char** argv)
     data["pagemeta"]["title"]="Toezegging " + nummer;
     data["og"]["title"] = "Toezegging "+nummer;
     data["og"]["description"] = eget(toez[0], "tekst");
-    data["og"]["imageurl"] = "";
     data["toez"]=packResultsJson(toez)[0];
     if(data["toez"]["pnummer"] != "")
       data["toez"]["pfractie"] = getPartyFromNumber(sqlw.get(), (int)data["toez"]["pnummer"]);
@@ -997,7 +992,6 @@ int main(int argc, char** argv)
     z["pagemeta"]["title"]="Zaak "+nummer;
     z["og"]["title"] = "Zaak " + nummer+" | " +  eget(zaken[0], "onderwerp");
     z["og"]["description"] = "Zaak " + eget(zaken[0], "titel") + " | " + eget(zaken[0], "onderwerp");
-    z["og"]["imageurl"] = "";
 
     inja::Environment e;
     e.set_html_autoescape(true);
@@ -1161,7 +1155,6 @@ int main(int argc, char** argv)
       data["pagemeta"]["title"]="";
       data["og"]["title"] = name;
       data["og"]["description"] = name;
-      data["og"]["imageurl"] = "";
 
       res.set_content(e.render_file("./partials/"+file, data), "text/html");
     });
@@ -1254,7 +1247,6 @@ int main(int argc, char** argv)
     data["pagemeta"]["title"]="Hoofdpagina – OpenTK";
     data["og"]["title"] = "Recente documenten";
     data["og"]["description"] = "Recente documenten uit de Tweede Kamer";
-    data["og"]["imageurl"] = "";
     
     res.set_content(e.render_file("./partials/index.html", data), "text/html");
   });
@@ -1327,7 +1319,6 @@ int main(int argc, char** argv)
     data["pagemeta"]["title"]="OpenTK - Toezeggingen";
     data["og"]["title"] = "OpenTK - Toezeggingen";
     data["og"]["description"] = "Toezeggingen van het kabinet";
-    data["og"]["imageurl"] = "";
     data["data"] = filtered;
     data["voortouw"] = commissie;
     data["fractie"] = fractie;
@@ -1481,7 +1472,6 @@ int main(int argc, char** argv)
     data["pagemeta"]["title"]="Open Vragen – OpenTK";
     data["og"]["title"] = "Open vragen";
     data["og"]["description"] = "Open vragen uit de Tweede Kamer";
-    data["og"]["imageurl"] = "";
 
     res.set_content(e.render_file("./partials/open-vragen.html", data), "text/html");
   });
@@ -1541,7 +1531,6 @@ int main(int argc, char** argv)
     data["pagemeta"]["title"]="Besluiten – OpenTK";
     data["og"]["title"] = "Recente en toekomstige besluiten";
     data["og"]["description"] = "Recente en toekomstige besluiten in de Tweede Kamer";
-    data["og"]["imageurl"] = "";
     
     res.set_content(e.render_file("./partials/besluiten.html", data), "text/html");
   });
@@ -1563,7 +1552,6 @@ int main(int argc, char** argv)
     data["pagemeta"]["title"]="Activiteit – OpenTK";
     data["og"]["title"] = act[0]["onderwerp"];
     data["og"]["description"] = (string)act[0]["datum"] + ": "+ (string)act[0]["onderwerp"];
-    data["og"]["imageurl"] = "";
     
     res.set_content(e.render_file("./partials/activiteit.html", data), "text/html");
   });
@@ -1629,7 +1617,6 @@ int main(int argc, char** argv)
     data["pagemeta"]["title"]="Activiteiten – OpenTK";
     data["og"]["title"] = "Activiteiten";
     data["og"]["description"] = "Activiteiten Tweede Kamer";
-    data["og"]["imageurl"] = "";
     
     res.set_content(e.render_file("./partials/activiteiten.html", data), "text/html");
   });
@@ -1674,7 +1661,6 @@ int main(int argc, char** argv)
     data["pagemeta"]["title"]="Ongeplande activiteiten – OpenTK";
     data["og"]["title"] = "Ongeplande activiteiten";
     data["og"]["description"] = "Ongeplande activiteiten Tweede Kamer";
-    data["og"]["imageurl"] = "";
 
     res.set_content(e.render_file("./partials/ongeplande-activiteiten.html", data), "text/html");
   });
@@ -1695,7 +1681,6 @@ int main(int argc, char** argv)
     data["pagemeta"]["title"]= eget(deets[0], "naam");
     data["og"]["title"] = eget(deets[0], "naam");
     data["og"]["description"] = eget(deets[0], "naam");
-    data["og"]["imageurl"] = "";
 
     data["id"] = id;
     data["naam"] = eget(deets[0], "naam");
@@ -1725,7 +1710,6 @@ int main(int argc, char** argv)
     data["pagemeta"]["title"]="";
     data["og"]["title"] = docs[0]["titel"];
     data["og"]["description"] = docs[0]["titel"];
-    data["og"]["imageurl"] = "";
     
     res.set_content(e.render_file("./partials/ksd.html", data), "text/html");
   });
@@ -1932,7 +1916,6 @@ int main(int argc, char** argv)
     data["pagemeta"]["title"]=get<string>(ret[0]["onderwerp"]);
     data["og"]["title"] = get<string>(ret[0]["onderwerp"]);
     data["og"]["description"] = get<string>(ret[0]["titel"]) + " " +get<string>(ret[0]["onderwerp"]);
-    data["og"]["imageurl"] = "";
 
     bulkEscape(data); 
 
@@ -2014,7 +1997,6 @@ int main(int argc, char** argv)
     data["pagemeta"]["title"]=(string)data["titel"];
     data["og"]["title"] = (string)data["titel"];
     data["og"]["description"] = (string)data["updated"] + " " + (string)data["titel"];
-    data["og"]["imageurl"] = "";
 
     bulkEscape(data); 
     data["htmlverslag"]=enrichHTML(getHtmlForDocument(data["id"], true), tp.getLease().get());
@@ -2063,7 +2045,6 @@ int main(int argc, char** argv)
     data["pagemeta"]["title"]=(string)data["titel"];
     data["og"]["title"] = (string)data["titel"];
     data["og"]["description"] = (string)data["mutatiedatumtijd"] + " " + (string)data["titel"];
-    data["og"]["imageurl"] = "";
 
     bulkEscape(data); 
     //    data["htmlverslag"]="";
@@ -2080,7 +2061,6 @@ int main(int argc, char** argv)
     data["pagemeta"]["title"]="Verslagen – OpenTK";
     data["og"]["title"] = "Recente verslagen";
     data["og"]["description"] = "Recente verslagen uit de Tweede Kamer";
-    data["og"]["imageurl"] = "";
     
     res.set_content(e.render_file("./partials/verslagen.html", data), "text/html");
   });
@@ -2158,7 +2138,6 @@ int main(int argc, char** argv)
     data["pagemeta"]["title"]="Stemmingen – OpenTK";
     data["og"]["title"] = "Stemmingen";
     data["og"]["description"] = "Stemmingen";
-    data["og"]["imageurl"] = "";
 
     res.set_content(e.render_file("./partials/stemmingen.html", data), "text/html");
   });
@@ -2359,7 +2338,6 @@ int main(int argc, char** argv)
     data["error"] = data["og"]["title"];
       
     data["og"]["description"] = "Een TKConv error: " + (string)data["error"];
-    data["og"]["imageurl"] = "";
     cout<<"Error: "<<req.path<<" '"<< (string)data["error"] <<"'"<<endl;
     res.set_content(e.render_file("./partials/error.html", data), "text/html");
   });


### PR DESCRIPTION
This removes the `pagemeta` and `og` required keys, and instead uses template inheritance to compute the page title and OpenGraph metadata for each page, depending on which partial is being rendered.

Besides making tkserv.cc a bit shorter, this has the following benefits:

- Views that use the `doTemplate` function (Commissies, Kamerstukdossiers, etc) can now set a proper title.
- The "OpenTK" suffix is now consistently applied to the page title.
- When improving the page title or OpenGraph metadata, it is no longer necessary to recompile tkserv.

