### PR TITLE
Add creature comfort command-line arguments to tkserv (--smtp-server etc)

### DIFF
--- a/tkserv.cc
+++ b/tkserv.cc
@@ -401,7 +401,9 @@ int main(int argc, char** argv)
   args.add_argument("port").help("Port number to use").default_value(8089);
   args.add_argument("root").help("Directory containing static assets").default_value("./html/");
   args.add_argument("--rnd-admin-password").help("Create admin user if necessary, and set a random password").default_value(string(""));
-  args.add_argument("--insecure-cookie").help("Use an insecure cookie, for non-https operations").default_value(string(""));
+  args.add_argument("--smtp-server").help("IP address or address:port of SMTP smart host").default_value("10.0.0.2");
+  args.add_argument("--sender-email").help("From address of email we send").default_value("opentk@hubertnet.nl");
+  args.add_argument("--base-url").help("URL of this instance without trailing slash, for use in email").default_value("https://berthub.eu/tkconv");
   args.add_argument("--dev").help("Increase SQLite log verbosity").flag();
   try {
     args.parse_args(argc, argv);
@@ -445,8 +447,7 @@ int main(int argc, char** argv)
   sws.d_svr.set_keep_alive_max_count(1); 
   sws.d_svr.set_keep_alive_timeout(1);
   sws.standardFunctions();
-  addTkUserManagement(sws, "10.0.0.2", "opentk@hubertnet.nl", "https://berthub.eu/tkconv");
-  //  addTkUserManagement(sws, "10.0.0.2", "opentk@hubertnet.nl", "http://127.0.0.1:8089");
+  addTkUserManagement(sws, args.get<string>("--smtp-server"), args.get<string>("--sender-email"), args.get<string>("--base-url"));
   
   
   if(args.is_used("--rnd-admin-password")) {

--- a/tkserv.cc
+++ b/tkserv.cc
@@ -397,6 +397,8 @@ int main(int argc, char** argv)
   
   argparse::ArgumentParser args("tkserv", "0.0");
 
+  args.add_argument("port").help("Port number to use").default_value(8089);
+  args.add_argument("root").help("Directory containing static assets").default_value("./html/");
   args.add_argument("--rnd-admin-password").help("Create admin user if necessary, and set a random password").default_value(string(""));
   args.add_argument("--insecure-cookie").help("Use an insecure cookie, for non-https operations").default_value(string(""));
   try {
@@ -2441,13 +2443,9 @@ int main(int argc, char** argv)
 
   sws.d_svr.set_payload_max_length(1024 * 1024); // 1MB
   
-  string root = "./html/";
-  if(argc > 2)
-    root = argv[2];
+  string root = args.get<string>("root");
   sws.d_svr.set_mount_point("/", root);
-  int port = 8089;
-  if(argc > 1)
-    port = atoi(argv[1]);
+  int port = args.get<int>("port");
   
   fmt::print("Listening on port {} serving html from {}, using {} threads\n",
 	     port, root, CPPHTTPLIB_THREAD_POOL_COUNT);

--- a/tkserv.cc
+++ b/tkserv.cc
@@ -18,6 +18,7 @@
 #include "thingpool.hh"
 #include "sws.hh"
 #include "search.hh"
+#include <sqlite3.h>
 
 using namespace std;
 void addTkUserManagement(SimpleWebSystem& sws, const std::string& mailserver,
@@ -401,6 +402,7 @@ int main(int argc, char** argv)
   args.add_argument("root").help("Directory containing static assets").default_value("./html/");
   args.add_argument("--rnd-admin-password").help("Create admin user if necessary, and set a random password").default_value(string(""));
   args.add_argument("--insecure-cookie").help("Use an insecure cookie, for non-https operations").default_value(string(""));
+  args.add_argument("--dev").help("Increase SQLite log verbosity").flag();
   try {
     args.parse_args(argc, argv);
   }
@@ -409,7 +411,12 @@ int main(int argc, char** argv)
     std::exit(1);
   }
 
-  
+  if (args["--dev"] == true) {
+    sqlite3_config(SQLITE_CONFIG_LOG, +[](void *, int iErrCode, const char *zMsg) {
+      std::cout << "SQLite: " << zMsg << " (" << iErrCode << ")" << std::endl;
+    }, nullptr);
+  }
+
   ThingPool<SQLiteWriter> tp("tk.sqlite3", SQLWFlag::ReadOnly);
   tp.setInit([](SQLiteWriter& sqlw) {
     sqlw.query("ATTACH DATABASE 'oo.sqlite3' as oo");


### PR DESCRIPTION
This adds a few command-line arguments to make it a bit easier to run and debug "unofficial" instances of tkserv:

- `--smtp-server` takes an IP address and port of a mail server to use for user invites and such, rather than being hardcoded to 10.0.0.2:25; for [Mailpit](https://mailpit.axllent.org) one would set `127.0.0.1:1025` for example. Taken from `tkbot`.
- `--sender-email` and `--base-url` tweak the message that gets sent in such cases.
- `--dev` for now just adds some additional SQLite logging.
- `--insecure-cookie` is removed; tkserv never sends Secure cookies, with or without the flag.

The `port` and `root` arguments are now parsed using argparse; this avoids `tkserv` getting confused if these are not given but flags are given.