### PR TITLE
Add "on this day" filter for activiteiten (limited date filter)

### DIFF
--- a/partials/activiteiten.html
+++ b/partials/activiteiten.html
@@ -23,17 +23,15 @@
   </ul>
   <ul>
     {% if meta.datum == "" %}
-    <li><a href="./activiteiten.html?datum={{meta.vandaag}}">🗓️ Datum kiezen</a></li>
     <li><a href="#vandaag">⏩ Spring naar vandaag</a></li>
+    <li><a href="./activiteiten.html?datum={{meta.vandaag}}">🗓️ Datum kiezen</a></li>
     {% else %}
+    <li><a href="./activiteiten.html">⏩ Terug naar overzicht</a></li>
     <li style="padding-top: 0; padding-bottom: 0;">
       <form id="datum" style="display: inline">
-        <input style="display: inline; width: auto" type="date" name="datum" value="{{meta.datum}}" onchange="if (!this.value.startsWith('0')) document.forms.datum.submit()">
-        <noscript><input type="submit"></noscript>
+        <input style="display: inline; width: auto" type="date" name="datum" value="{{meta.datum}}">
+        <input style="display: inline; width: auto" type="submit" value="►">
       </form>
-    </li>
-    <li style="padding-top: 0; padding-bottom: 0;">
-    <li><a href="./activiteiten.html">⏩ Terug naar overzicht</a></li>
     </li>
     {% endif %}
   </ul>

--- a/partials/activiteiten.html
+++ b/partials/activiteiten.html
@@ -1,15 +1,45 @@
 {% extends "base.html" %}
 
 {% block main %}
-<h4>Recente en toekomstige activiteiten
-  {%if meta.commissie != "" %}
-  van de {{ meta.commissienaam }}
-  {%endif%}
+<h4>
+  {% if meta.datum != "" %}
+  Alle activiteiten op {{ meta.datum }}
+  {% else %}
+  Recente en toekomstige activiteiten
+  {% if meta.commissie != "" %}
+  van de {{ default(meta.commissienaam, "commissie") }}
+  {% endif %}
+  {% endif %}
 </h4>
-<p>
-  Activiteiten vanaf vier dagen geleden. Of <a href="#vandaag">spring ⏩ naar vandaag</a>.
-</p>
+<nav>
+  <ul>
+    <li>
+      {% if meta.datum == "" %}
+      Activiteiten vanaf vier dagen geleden.
+      {% else %}
+      Er zijn {{ length(data) }} resultaten gevonden voor de opgegeven datum.
+      {% endif %}
+    </li>
+  </ul>
+  <ul>
+    {% if meta.datum == "" %}
+    <li><a href="./activiteiten.html?datum={{meta.vandaag}}">🗓️ Datum kiezen</a></li>
+    <li><a href="#vandaag">⏩ Spring naar vandaag</a></li>
+    {% else %}
+    <li style="padding-top: 0; padding-bottom: 0;">
+      <form id="datum" style="display: inline">
+        <input style="display: inline; width: auto" type="date" name="datum" value="{{meta.datum}}" onchange="document.forms.datum.submit()">
+        <noscript><input type="submit"></noscript>
+      </form>
+    </li>
+    <li style="padding-top: 0; padding-bottom: 0;">
+    <li><a href="./activiteiten.html">⏩ Terug naar overzicht</a></li>
+    </li>
+    {% endif %}
+  </ul>
+</nav>
 <center>
+  {% if meta.datum == "" %}
   {%if meta.commissie != "" %}
   <a href="./activiteiten.html">Alles</a>
   {%else%}
@@ -21,6 +51,7 @@
     <abbr title="{{d.naam}}">{{ d.afko }}</abbr>
     {% if d.afko != meta.commissie %}</a>{%else%}</b>{%endif%}
 {% endfor %}
+{% endif %}
 </center>
 <table class="striped">
   <thead>

--- a/partials/activiteiten.html
+++ b/partials/activiteiten.html
@@ -28,7 +28,7 @@
     {% else %}
     <li style="padding-top: 0; padding-bottom: 0;">
       <form id="datum" style="display: inline">
-        <input style="display: inline; width: auto" type="date" name="datum" value="{{meta.datum}}" onchange="document.forms.datum.submit()">
+        <input style="display: inline; width: auto" type="date" name="datum" value="{{meta.datum}}" onchange="if (!this.value.startsWith('0')) document.forms.datum.submit()">
         <noscript><input type="submit"></noscript>
       </form>
     </li>

--- a/tkserv.cc
+++ b/tkserv.cc
@@ -1569,12 +1569,22 @@ int main(int argc, char** argv)
   });
 
   sws.d_svr.Get("/activiteiten.html", [&tp](const httplib::Request &req, httplib::Response &res) {
-    // from 4 days ago into the future
-    string dlim = getDateDBFormat(time(0)-4*86400);
+    string earliest, latest;
+    string dlim = req.get_param_value("datum");
+
+    if (dlim.empty()) {
+      // from 4 days ago into the future
+      earliest = getDateDBFormat(time(0)-4*86400);
+      latest = getDateDBFormat(time(0)+20*365*86400);
+    } else {
+      // only one day. don't offer wider ranges for now
+      earliest = getDateDBFormat(getDateTimestamp(dlim));
+      latest = getDateDBFormat(getDateTimestamp(dlim));
+    }
 
     string today = getTodayDBFormat();
     
-    auto acts = packResultsJson(tp.getLease()->queryT("select Activiteit.datum datum, activiteit.bijgewerkt bijgewerkt, activiteit.nummer nummer, naam, noot, onderwerp, besloten, voortouwAfkorting, voortouwNaam from Activiteit left join Reservering on reservering.activiteitId=activiteit.id  left join Zaal on zaal.id=reservering.zaalId where datum > ? order by datum asc", {dlim}));
+    auto acts = packResultsJson(tp.getLease()->queryT("select Activiteit.datum datum, activiteit.bijgewerkt bijgewerkt, activiteit.nummer nummer, naam, noot, onderwerp, besloten, voortouwAfkorting, voortouwNaam from Activiteit left join Reservering on reservering.activiteitId=activiteit.id  left join Zaal on zaal.id=reservering.zaalId where Activiteit.datum between date(?) and date(?, '+1 day') order by datum asc", {earliest, latest}));
 
     bool noMarkerYet = true;
     struct Commie
@@ -1611,6 +1621,8 @@ int main(int argc, char** argv)
     nlohmann::json data = nlohmann::json::object();
     data["data"] = acts;
     data["meta"]["commissie"] = commissie; 
+    data["meta"]["datum"] = dlim.empty() ? "" : earliest;
+    data["meta"]["vandaag"] = today;
     data["meta"]["commies"] = nlohmann::json::array();
     for(const auto& c : commies) {
       nlohmann::json commie = nlohmann::json::object();


### PR DESCRIPTION
This makes it so the activiteiten view now supports filtering by a specific date (and then showing activity from all commissions) in addition to filtering by a commission (and then showing recent and future entries).

The existing behavior is still the default:

> <img width="1920" height="1200" alt="20260525_00h19m59s_grim" src="https://github.com/user-attachments/assets/b4c7ec20-d283-4545-9240-1ecfee1aa041" />

The new button "Datum kiezen" switches to the day-at-a-time view with a little native date picker:

> <img width="1920" height="1200" alt="20260525_00h20m12s_grim" src="https://github.com/user-attachments/assets/46844c97-71c2-42b4-80ca-f0c3860ff591" />

Either clicking [activiteiten], clicking "Terug naar overzicht", clicking the back button, or clearing the date field will return to the existing overview.

This feature does not let users pick an arbitrary date range; there are quite a lot of activiteiten, and I wanted to avoid a situation where someone would accidentally or maliciously request all 70.000 at once.

In theory, this is intended to help with questions like #97, but I have not been able to find the motions being referred to there in my local instance.