### PR TITLE
Actions: Run apt-get update before install

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -23,7 +23,9 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install various apt dependencies
-      run: sudo apt-get install nlohmann-json3-dev libsqlite3-dev libpugixml-dev libssl-dev zlib1g-dev poppler-utils catdoc imagemagick pkg-config xmlstarlet libmagic-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install nlohmann-json3-dev libsqlite3-dev libpugixml-dev libssl-dev zlib1g-dev poppler-utils catdoc imagemagick pkg-config xmlstarlet libmagic-dev
 
 
     - name: Install meson


### PR DESCRIPTION
This resolves an issue where the GitHub Actions CI implementation was not able to find libpoppler/poppler-utils:

```
Err:30 mirror+file:/etc/apt/apt-mirrors.txt noble-updates/main amd64 libpoppler134 amd64 24.02.0-1ubuntu9.8
  404  Not Found [IP: 52.252.75.106 80]
Ign:35 https://security.ubuntu.com/ubuntu noble-updates/main amd64 poppler-utils amd64 24.02.0-1ubuntu9.8
Err:35 mirror+file:/etc/apt/apt-mirrors.txt noble-updates/main amd64 poppler-utils amd64 24.02.0-1ubuntu9.8
  404  Not Found [IP: 52.252.75.106 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/p/poppler/libpoppler134_24.02.0-1ubuntu9.8_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/p/poppler/poppler-utils_24.02.0-1ubuntu9.8_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```