### PR TITLE
Indicate search result itemlimit truncation in UI

### DIFF
--- a/html/logic.js
+++ b/html/logic.js
@@ -306,7 +306,12 @@ async function getSearchResults(f)
 	rssurl.searchParams.set("q", f.searchQuery);
 	f.rssurl = rssurl.href;
 
-	f.message = `< ${Math.ceil(data["milliseconds"])} milliseconden`;
+	if (data["truncated"]) {
+	    f.message = `De nieuwste ${f.foundDocs.length} resultaten worden getoond - probeer een specifiekere zoekvraag.`;
+	} else {
+	    f.message = `${f.foundDocs.length} resultaten in < ${Math.ceil(data["milliseconds"])} milliseconden`;
+	}
+
 	f.busy=false;
 	orderByDate(f, false);
     }

--- a/partials/search.html
+++ b/partials/search.html
@@ -115,9 +115,9 @@ kind: 'zoek'
   </tbody>
 </table>
 </template>
-<center><small>
+<small>
     <span x-text="message"></span>
-</small></center>
+</small>
 
 {% endblock %}
 	

--- a/sws.hh
+++ b/sws.hh
@@ -33,12 +33,12 @@ struct LockedSqw
     return packResultsJson(result);
   }
   
-  void addValue(const std::initializer_list<std::pair<const char*, SQLiteWriter::var_t>>& values, const std::string& table="data")
+  void addValue(const std::initializer_list<std::pair<std::string, SQLiteWriter::var_t>>& values, const std::string& table="data")
   {
     std::lock_guard<std::mutex> l(sqwlock);
     sqw.addValue(values, table);
   }
-  void addValue(const std::vector<std::pair<const char*, SQLiteWriter::var_t>>& values, const std::string& table="data")
+  void addValue(const std::vector<std::pair<std::string, SQLiteWriter::var_t>>& values, const std::string& table="data")
   {
     std::lock_guard<std::mutex> l(sqwlock);
     sqw.addValue(values, table);
@@ -117,10 +117,10 @@ struct SimpleWebSystem
     {
       return sws.getIP(req);
     }
-    void log(const std::initializer_list<std::pair<const char*, SQLiteWriter::var_t>>& fields)
+    void log(const std::initializer_list<std::pair<std::string, SQLiteWriter::var_t>>& fields)
     {
       // add agent?
-      std::vector<std::pair<const char*, SQLiteWriter::var_t>> values{{"user", user}, {"ip", getIP()}, {"tstamp", time(0)}};
+      std::vector<std::pair<std::string, SQLiteWriter::var_t>> values{{"user", user}, {"ip", getIP()}, {"tstamp", time(0)}};
       for(const auto& f : fields)
         values.push_back(f);
       lsqw.addValue(values, "log");

--- a/tkserv.cc
+++ b/tkserv.cc
@@ -2238,6 +2238,7 @@ int main(int argc, char** argv)
     dt.start();
 
     int mseclimit = 10000;
+    int itemlimit = 280;
 
     shared_ptr<int> uc = s_uc;
     
@@ -2258,7 +2259,14 @@ int main(int argc, char** argv)
 
     fmt::print("Categories: {}\n", categories);
 
-    auto sres = sh.search(term, categories, limit, mseclimit, 280);
+    auto sres = sh.search(term, categories, limit, mseclimit, itemlimit + 1);
+    bool truncated = false;
+
+    if (sres.size() > itemlimit) {
+      sres.pop_back();
+      truncated = true;
+    }
+
     nlohmann::json results = nlohmann::json::array();
     for(const auto& r : sres) {
       
@@ -2283,13 +2291,16 @@ int main(int argc, char** argv)
 	  }));
 				       
     }
+
     
     // soorten!
     auto usec = dt.lapUsec();
     fmt::print("Got {} matches in {} msec\n", results.size(), usec/1000.0);
     g_stats.searchUsec += usec;
     nlohmann::json response=nlohmann::json::object();
+
     response["results"]= results;
+    response["truncated"] = truncated;
 
     response["milliseconds"] = usec/1000.0;
     res.set_content(response.dump(), "application/json");


### PR DESCRIPTION
This is based on https://github.com/berthubert/tkconv/issues/140, but with a slight twist; the item limit is still not documented because I imagine it is not guaranteed and may change in future, but the response does now indicate whether truncation has happened. This is also exposed to the user interface, which recommends asking a more specific query.

Normal case, fewer than 280 results:

> <img width="1131" height="958" alt="2026-08-18 23 07 10 localhost 0aac3141e94c" src="https://github.com/user-attachments/assets/e2169198-8658-4da4-b618-773d28c13e58" />

Truncated case, 280 results (but there could be more):

> <img width="1091" height="304" alt="2026-08-18 23 07 47 localhost 7ff1f8f6cabf" src="https://github.com/user-attachments/assets/ac4445ef-79f1-47ee-ad44-95339c0830d5" />

The total number of potential matches is not returned.

This PR also contains the changes from https://github.com/berthubert/tkconv/pull/149.

This is technically independent of the changes in https://github.com/berthubert/tkconv/pull/150 but it would probably be least confusing to merge that first.